### PR TITLE
Refactor create PR command to use getGitHubToken for authentication

### DIFF
--- a/src/commands/create-pr-command.ts
+++ b/src/commands/create-pr-command.ts
@@ -1,5 +1,5 @@
-import { PullRequest } from "@/github";
-import { Config, readConfig } from "@/config";
+import { getGitHubToken, PullRequest } from "@/github";
+import { readConfig } from "@/config";
 import { Octokit } from "octokit";
 import { generateSummary } from "@/github/summary";
 import {
@@ -74,14 +74,11 @@ export async function executeCreatePRCommand(values: any) {
   }
 
   // create a pull request
+  const gitHubToken = await getGitHubToken();
   if (dryRun) {
     console.log(`Dry run: would create a pull request`);
   } else {
-    const token = Bun.env.GITHUB_TOKEN;
-    if (!token) {
-      throw new Error("GITHUB_TOKEN is not set");
-    }
-    const octokit = new Octokit({ auth: token });
+    const octokit = new Octokit({ auth: gitHubToken });
     const { owner, repo } = await getOriginOwnerAndRepo(gitRoot);
     const response = await octokit.rest.repos.get({
       owner,

--- a/src/github.ts
+++ b/src/github.ts
@@ -103,3 +103,24 @@ export class PullRequest {
     return response.data.default_branch;
   }
 }
+
+export async function getGitHubToken(): Promise<string> {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    // try to get token from gh
+    const result = Bun.spawn({
+      cmd: ["gh", "auth", "token"],
+    });
+    await result.exited;
+    if (result.exitCode !== 0) {
+      throw new Error(
+        "Failed to get GitHub token from environment variable or gh",
+      );
+    }
+    const text = (await new Response(result.stdout).text()).trim();
+    if (text) {
+      return text;
+    }
+  }
+  return token;
+}


### PR DESCRIPTION
| Category | Description |
|---|---|
| refactor | Remove unused 'Config' import from create-pr-command.ts. |
| refactor | Import 'getGitHubToken' function from '@/github'. |
| enhance | Add 'getGitHubToken' function to improve GitHub token retrieval from environment variable or 'gh' CLI. |
| refactor | Replace direct environment variable access with 'getGitHubToken' in create-pr-command.ts. |