### PR TITLE
Refactor error handling by introducing CommandError class

### DIFF
--- a/src/commands/error.ts
+++ b/src/commands/error.ts
@@ -1,0 +1,5 @@
+export class CommandError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { executeReviewCommand } from "@/commands/review-command";
 import pkg from "../package.json";
 import { executeSummaryDiffCommand } from "@/commands/summary-diff-command";
 import { executeCreatePRCommand } from "./commands/create-pr-command";
+import { CommandError } from "./commands/error";
 
 const argv = yargs(process.argv.slice(2))
   .option("config", {
@@ -78,23 +79,32 @@ const values = {
   dir: argv.dir,
   slack: argv.slack,
   pattern: argv.pattern,
-  dryRun: argv.dryRun,
+  dryRun: argv.dryRun || false,
+  stageOnly: argv.stageOnly || false,
 };
 
 const subcommand = argv._[0];
-switch (subcommand) {
-  case "review":
-    executeReviewCommand(values);
-    break;
-  case "commit-message":
-    executeCommitMessageCommand(values);
-    break;
-  case "summary-diff":
-    executeSummaryDiffCommand(values);
-    break;
-  case "create-pr":
-    executeCreatePRCommand(values);
-    break;
-  default:
-    console.error("Unknown subcommand:", subcommand);
+try {
+  switch (subcommand) {
+    case "review":
+      executeReviewCommand(values);
+      break;
+    case "commit-message":
+      executeCommitMessageCommand(values);
+      break;
+    case "summary-diff":
+      executeSummaryDiffCommand(values);
+      break;
+    case "create-pr":
+      executeCreatePRCommand(values);
+      break;
+    default:
+      console.error("Unknown subcommand:", subcommand);
+  }
+} catch (error) {
+  if (error instanceof CommandError) {
+    console.error(error.message);
+  } else {
+    throw error;
+  }
 }


### PR DESCRIPTION
| Category | Description |
|---|---|
| enhance | Introduced the CommandError class for more specific error handling. |
| refactor | Replaced generic Error instances with CommandError in create-pr-command.ts. |
| enhance | Added console.log statements for dryRun and stageOnly variables to improve debugging. |
| enhance | Wrapped subcommand execution in a try-catch block to gracefully handle CommandError exceptions. |
| enhance | Added a check for pushResult.exitCode and threw a CommandError if the push failed. |