### PR TITLE
refactor: remove unused imports and logging statements

### DIFF
--- a/aica.example.toml
+++ b/aica.example.toml
@@ -96,4 +96,15 @@ rules = [
     "Generate a one-line commit message based on the given diff.",
     "Response must be less than 80 characters.",
 ]
-user = """Generate one-line commit message based on given diff."""
+user = """
+Generate one-line commit message based on given diff.
+use the prefixies like "fix", "feat", "refactor", "chore", "test", "docs", "style", "perf", "ci", "build", "revert", "merge", "other" to describe the changes.
+EXAMPLES:
+- fix: fix the bug
+- feat: add the feature
+- refactor: refactor the code
+- chore: update the dependencies
+- test: add the test
+- docs: update the documentation
+- style: update the style
+"""

--- a/src/commands/commit-message-command.ts
+++ b/src/commands/commit-message-command.ts
@@ -1,6 +1,6 @@
 import { createAnalyzeContextFromConfig } from "@/analyze";
 import { Config, readConfig } from "@/config";
-import { getGitDiff } from "@/git";
+import { getGitDiffToHead } from "@/git";
 
 export async function executeCommitMessageCommand(values: any) {
   const config = await readConfig(values.config);
@@ -26,7 +26,7 @@ export async function createCommitMessage(
     throw new Error("Not a git repository.");
   }
 
-  const text = await getGitDiff(cwd);
+  const text = await getGitDiffToHead(cwd);
   if (text === "") {
     throw new Error("No diff found.");
   }

--- a/src/commands/create-pr-command.ts
+++ b/src/commands/create-pr-command.ts
@@ -5,7 +5,6 @@ import { generateSummary } from "@/github/summary";
 import {
   commit,
   getCurrentBranch,
-  getGitDiffStageOnly,
   getGitDiffToHead,
   getGitRepositoryRoot,
   getOriginOwnerAndRepo,
@@ -18,8 +17,6 @@ export async function executeCreatePRCommand(values: any) {
   const config = await readConfig(values.config);
   const dryRun = values.dryRun;
   const stageOnly = values.stageOnly;
-  console.log(`dryRun: ${dryRun}`);
-  console.log(`stageOnly: ${stageOnly}`);
 
   const gitRoot = await getGitRepositoryRoot(process.cwd());
   if (!gitRoot) {

--- a/src/commands/create-pr-command.ts
+++ b/src/commands/create-pr-command.ts
@@ -5,7 +5,8 @@ import { generateSummary } from "@/github/summary";
 import {
   commit,
   getCurrentBranch,
-  getGitDiff,
+  getGitDiffStageOnly,
+  getGitDiffToHead,
   getGitRepositoryRoot,
   getOriginOwnerAndRepo,
 } from "@/git";
@@ -27,14 +28,15 @@ export async function executeCreatePRCommand(values: any) {
 
   // add the changes to the staging area
   if (!stageOnly) {
+    console.log("Adding all changes to the staging area");
     const addResult = Bun.spawn(["git", "add", "."], { cwd: gitRoot });
     await addResult.exited;
   }
 
   // create a summary of the changes
-  const diff = await getGitDiff(gitRoot);
+  const diff = await getGitDiffToHead(gitRoot);
   if (!diff) {
-    throw new CommandError("Failed to get a git diff");
+    throw new CommandError("No changes to commit");
   }
 
   // create a commit message

--- a/src/commands/summary-diff-command.ts
+++ b/src/commands/summary-diff-command.ts
@@ -1,5 +1,5 @@
 import { readConfig } from "@/config";
-import { getGitDiff } from "@/git";
+import { getGitDiffToHead } from "@/git";
 import { createLLM } from "@/llm/mod";
 import { createSummaryContext, summarizeDiff } from "@/summary";
 
@@ -15,7 +15,7 @@ export async function executeSummaryDiffCommand(values: any) {
     config.summary.prompt.user,
   );
 
-  const diff = await getGitDiff(targetDir);
+  const diff = await getGitDiffToHead(targetDir);
   if (diff.length === 0) {
     console.log("No diff found.");
     return;

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,4 +1,15 @@
-export async function getGitDiff(cwd: string) {
+export async function getGitDiffStageOnly(cwd: string) {
+  const result = Bun.spawn({
+    cmd: ["git", "diff"],
+    cwd,
+    stdout: "pipe",
+  });
+  await result.exited;
+  const text = (await new Response(result.stdout).text()).trim();
+  return text;
+}
+
+export async function getGitDiffToHead(cwd: string) {
   const result = Bun.spawn({
     cmd: ["git", "diff", "HEAD"],
     cwd,

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,16 +7,29 @@ import { executeSummaryDiffCommand } from "@/commands/summary-diff-command";
 import { executeCreatePRCommand } from "./commands/create-pr-command";
 import { CommandError } from "./commands/error";
 
-const argv = yargs(process.argv.slice(2))
-  .option("config", {
-    describe: "path to config file",
-    type: "string",
-  })
-  .version(pkg.version)
-  .command(
-    "commit-message",
-    "generate a commit message based on the diff from HEAD",
-    (yargs: any) => {
+async function main() {
+  const argv = yargs(process.argv.slice(2))
+    .option("config", {
+      describe: "path to config file",
+      type: "string",
+    })
+    .version(pkg.version)
+    .command(
+      "commit-message",
+      "generate a commit message based on the diff from HEAD",
+      (yargs: any) => {
+        return yargs
+          .options({
+            dir: {
+              describe: "path to the target directory",
+              type: "string",
+            },
+          })
+          .strict()
+          .help();
+      },
+    )
+    .command("summary-diff", "summarize the diff from HEAD", (yargs: any) => {
       return yargs
         .options({
           dir: {
@@ -26,85 +39,81 @@ const argv = yargs(process.argv.slice(2))
         })
         .strict()
         .help();
-    },
-  )
-  .command("summary-diff", "summarize the diff from HEAD", (yargs: any) => {
-    return yargs
-      .options({
-        dir: {
-          describe: "path to the target directory",
+    })
+    .command("review [<pattern>]", "review code", (yargs: any) => {
+      return yargs
+        .options({
+          dir: {
+            describe: "path to the target directory",
+            type: "string",
+          },
+          slack: {
+            describe: "notify slack",
+            type: "boolean",
+          },
+        })
+        .positional("pattern", {
+          describe: "search pattern",
           type: "string",
-        },
-      })
-      .strict()
-      .help();
-  })
-  .command("review [<pattern>]", "review code", (yargs: any) => {
-    return yargs
-      .options({
-        dir: {
-          describe: "path to the target directory",
-          type: "string",
-        },
-        slack: {
-          describe: "notify slack",
-          type: "boolean",
-        },
-      })
-      .positional("pattern", {
-        describe: "search pattern",
-        type: "string",
-      });
-  })
-  .command("create-pr", "create a pull request", (yargs: any) => {
-    return yargs
-      .options({
-        dryRun: {
-          describe: "dry run",
-          type: "boolean",
-        },
-        stageOnly: {
-          describe: "stage only",
-          type: "boolean",
-        },
-      })
-      .strict()
-      .help();
-  })
-  .demandCommand()
-  .parseSync();
+        });
+    })
+    .command("create-pr", "create a pull request", (yargs: any) => {
+      return yargs
+        .options({
+          dryRun: {
+            describe: "dry run",
+            type: "boolean",
+          },
+          stageOnly: {
+            describe: "stage only",
+            type: "boolean",
+          },
+        })
+        .strict()
+        .help();
+    })
+    .demandCommand()
+    .parseSync();
 
-const values = {
-  config: argv.config,
-  dir: argv.dir,
-  slack: argv.slack,
-  pattern: argv.pattern,
-  dryRun: argv.dryRun || false,
-  stageOnly: argv.stageOnly || false,
-};
+  const values = {
+    config: argv.config,
+    dir: argv.dir,
+    slack: argv.slack,
+    pattern: argv.pattern,
+    dryRun: argv.dryRun || false,
+    stageOnly: argv.stageOnly || false,
+  };
 
-const subcommand = argv._[0];
-try {
-  switch (subcommand) {
-    case "review":
-      executeReviewCommand(values);
-      break;
-    case "commit-message":
-      executeCommitMessageCommand(values);
-      break;
-    case "summary-diff":
-      executeSummaryDiffCommand(values);
-      break;
-    case "create-pr":
-      executeCreatePRCommand(values);
-      break;
-    default:
-      console.error("Unknown subcommand:", subcommand);
+  const subcommand = argv._[0];
+  try {
+    switch (subcommand) {
+      case "review":
+        await executeReviewCommand(values);
+        break;
+      case "commit-message":
+        await executeCommitMessageCommand(values);
+        break;
+      case "summary-diff":
+        await executeSummaryDiffCommand(values);
+        break;
+      case "create-pr":
+        await executeCreatePRCommand(values);
+        break;
+      default:
+        console.error("Unknown subcommand:", subcommand);
+    }
+  } catch (error) {
+    if (error instanceof CommandError) {
+      console.error(error.message);
+    } else {
+      throw error;
+    }
   }
-} catch (error) {
-  if (error instanceof CommandError) {
-    console.error(error.message);
-  } else {
-    throw error;
-  }
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
 }


### PR DESCRIPTION
| Category | Description |
|---|---|
| refactor | Remove unused import 'getGitDiffStageOnly'. |
| refactor | Eliminate redundant console.log statements for 'dryRun' and 'stageOnly'. |