### PR TITLE
ci: add executable check step to workflow

### DIFF
--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -27,3 +27,6 @@ jobs:
       # Run build to make sure it works
       - name: Run build
         run: bun run build
+
+      - name: Check executable
+        run: ./dist/aica --help


### PR DESCRIPTION
| Category | Description |
|---|---|
| enhance | Add a CI workflow step to verify the executable by running './dist/aica --help'. |