### PR TITLE
feat: add dryRun support and improve git staging flow

### DIFF
--- a/aica.example.toml
+++ b/aica.example.toml
@@ -3,7 +3,7 @@
 provider = 'openai'
 
 [llm.openai]
-model = 'o1-mini-2024-09-12'
+model = 'o3-mini'
 
 [llm.anthropic]
 model = 'claude-3-5-sonnet-20241022'

--- a/src/commands/commit-command.ts
+++ b/src/commands/commit-command.ts
@@ -1,22 +1,72 @@
-import { readConfig } from "@/config";
-import { getGitRepositoryRoot, commit, getGitDiffToHead } from "@/git";
+import { Config, readConfig } from "@/config";
+import {
+  getGitRepositoryRoot,
+  commit,
+  getGitDiffToHead,
+  getAddingFilesToStage,
+  addFilesToStage,
+  getAllChangedFiles,
+} from "@/git";
 import { createCommitMessageFromDiff } from "./commit-message-command";
 import { CommandError } from "./error";
 
-export async function executeCommitCommand(values: any) {
+export type CommitCommandResult = {
+  changedFiles: string[];
+  hasCommited: boolean;
+  commitMessage: string;
+  diff: string;
+};
+
+export async function executeCommitCommand(
+  values: any,
+): Promise<CommitCommandResult> {
   const config = await readConfig(values.config);
   const stageOnly = values.stageOnly;
+  const dryRun = values.dryRun;
 
   const gitRoot = await getGitRepositoryRoot(process.cwd());
   if (!gitRoot) {
-    throw new CommandError("Not a git repository.");
+    throw new CommandError("Not in a git repository.");
+  }
+  return executeCommit(gitRoot, config, stageOnly, dryRun);
+}
+
+export async function executeCommit(
+  gitRoot: string,
+  config: Config,
+  stageOnly: boolean,
+  dryRun: boolean,
+): Promise<CommitCommandResult> {
+  const changes = await getAddingFilesToStage(gitRoot);
+  if (!stageOnly) {
+    if (changes.confirmationRequiredFiles.length > 0) {
+      throw new CommandError(
+        "The following files are too large to add to the staging area:\n" +
+          changes.confirmationRequiredFiles
+            .map((file) => `- ${file.file}`)
+            .join("\n"),
+      );
+    }
+    if (dryRun) {
+      console.log(
+        "Dry run: would add the following files to the staging area:\n" +
+          changes.addingFiles.map((file) => `- ${file}`).join("\n"),
+      );
+    } else {
+      await addFilesToStage(gitRoot, changes.addingFiles);
+      console.log("Added all changes to the staging area");
+    }
   }
 
-  // add the changes to the staging area
-  if (!stageOnly) {
-    const addResult = Bun.spawn(["git", "add", "."], { cwd: gitRoot });
-    await addResult.exited;
-    console.log("Added all changes to the staging area");
+  const allChangedFiles = await getAllChangedFiles(gitRoot);
+  if (allChangedFiles.stagedFiles.length === 0) {
+    console.log("No changes to commit");
+    return {
+      changedFiles: [],
+      hasCommited: false,
+      commitMessage: "",
+      diff: "",
+    };
   }
 
   // create a summary of the changes
@@ -31,10 +81,29 @@ export async function executeCommitCommand(values: any) {
     throw new CommandError("Failed to create a commit message");
   }
 
-  const success = await commit(gitRoot, commitMessage);
-  if (!success) {
-    throw new CommandError("Failed to commit");
+  if (dryRun) {
+    const files = [
+      ...allChangedFiles.stagedFiles,
+      ...allChangedFiles.unstagedFiles,
+      ...allChangedFiles.untrackedFiles,
+    ];
+    console.log(
+      `Dry run: would commit with message "${commitMessage}" \n commit files:\n - ${files.join(
+        "\n - ",
+      )}`,
+    );
+  } else {
+    const success = await commit(gitRoot, commitMessage);
+    if (!success) {
+      throw new CommandError("Failed to commit");
+    }
+    console.log(`Successfully committed with message: "${commitMessage}"`);
   }
 
-  console.log(`Successfully committed with message: "${commitMessage}"`);
+  return {
+    changedFiles: allChangedFiles.stagedFiles,
+    hasCommited: true,
+    commitMessage,
+    diff,
+  };
 }

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "bun:test";
+import { getAllChangedFiles } from "./git";
+import { beforeEach, afterEach } from "bun:test";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { execSync } from "node:child_process";
+
+describe("getAllChangedFiles", () => {
+  const testDir = join(process.cwd(), "test-repo");
+
+  beforeEach(async () => {
+    // テスト用のGitリポジトリを作成
+    await mkdir(testDir, { recursive: true });
+    execSync("git init", { cwd: testDir });
+    execSync('git config user.email "test@example.com"', { cwd: testDir });
+    execSync('git config user.name "Test User"', { cwd: testDir });
+  });
+
+  afterEach(async () => {
+    // テスト用のディレクトリを削除
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it("should detect no changes in empty repository", async () => {
+    const result = await getAllChangedFiles(testDir);
+    expect(result.hasChanges).toBe(false);
+    expect(result.stagedFiles).toEqual([]);
+    expect(result.unstagedFiles).toEqual([]);
+    expect(result.untrackedFiles).toEqual([]);
+  });
+
+  it("should detect untracked files", async () => {
+    await writeFile(join(testDir, "untracked.txt"), "test");
+    const result = await getAllChangedFiles(testDir);
+    expect(result.hasChanges).toBe(true);
+    expect(result.untrackedFiles).toEqual(["untracked.txt"]);
+    expect(result.stagedFiles).toEqual([]);
+    expect(result.unstagedFiles).toEqual([]);
+  });
+
+  it("should detect staged files", async () => {
+    await writeFile(join(testDir, "staged.txt"), "test");
+    execSync("git add staged.txt", { cwd: testDir });
+    const result = await getAllChangedFiles(testDir);
+    expect(result.hasChanges).toBe(true);
+    expect(result.stagedFiles).toEqual(["staged.txt"]);
+    expect(result.unstagedFiles).toEqual([]);
+    expect(result.untrackedFiles).toEqual([]);
+  });
+
+  it("should detect unstaged changes in tracked files", async () => {
+    // ファイルを作成してコミット
+    await writeFile(join(testDir, "modified.txt"), "initial");
+    execSync("git add modified.txt", { cwd: testDir });
+    execSync('git commit -m "Initial commit"', { cwd: testDir });
+
+    // ファイルを変更
+    await writeFile(join(testDir, "modified.txt"), "modified");
+    const result = await getAllChangedFiles(testDir);
+    expect(result.hasChanges).toBe(true);
+    expect(result.unstagedFiles).toEqual(["modified.txt"]);
+    expect(result.stagedFiles).toEqual([]);
+    expect(result.untrackedFiles).toEqual([]);
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -84,6 +84,10 @@ async function main() {
               describe: "stage only",
               type: "boolean",
             },
+            dryRun: {
+              describe: "dry run",
+              type: "boolean",
+            },
           })
           .strict()
           .help();


### PR DESCRIPTION
| Category | Description |
|---|---|
| enhance | Updated the LLM model in aica.example.toml from 'o1-mini-2024-09-12' to 'o3-mini', implying a configuration change for model usage. |
| enhance | In commit-command.ts, introduced a new typed return (CommitCommandResult) and added support for a 'dryRun' option to conditionally log actions instead of executing them. |
| enhance | Refactored commit-command.ts by extracting commit logic into a separate function (executeCommit) and improved error messages for clarity. |
| refactor | In create-pr-command.ts, removed duplicate staging and committing logic by reusing the executeCommit function. |
| feature | Enhanced git.ts with new helper functions (addFilesToStage and getAddingFilesToStage) that perform file safety checks (e.g., file size and .env files) before staging changes. |
| enhance | Improved the getAllChangedFiles function in git.ts to accurately detect staged, unstaged, and untracked files using git commands. |
| enhance | Added new tests in git.test.ts to verify the behavior of getAllChangedFiles under various repository states (empty, untracked, staged, and modified files). |
| feature | Added a new 'dryRun' CLI option in main.ts, enabling a mode for simulating staging and commit operations without making actual changes. |