### PR TITLE
fix: update default OpenAI model to o3-mini

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -81,7 +81,7 @@ export const defaultConfig: Config = {
   llm: {
     provider: "openai",
     openai: {
-      model: Bun.env.OPENAI_MODEL || "o1-mini-2024-09-12",
+      model: Bun.env.OPENAI_MODEL || "o3-mini",
       apiKey: Bun.env.OPENAI_API_KEY || "",
     },
     anthropic: {


### PR DESCRIPTION
| Category | Description |
|---|---|
| enhance | Update the default OpenAI model from 'o1-mini-2024-09-12' to 'o3-mini' in the configuration file. |