### PR TITLE
fix: update bun version and correct lock file name

### DIFF
--- a/Dockerfile.github_actions
+++ b/Dockerfile.github_actions
@@ -1,9 +1,9 @@
-FROM oven/bun:1.1.42
+FROM oven/bun:1.2.2
 
 WORKDIR /app
 COPY package.json .
 COPY tsconfig.json .
-COPY bun.lockb .
+COPY bun.lock .
 COPY src /app/src
 RUN bun install
 RUN bun run build:actions


### PR DESCRIPTION
| Category | Description |
|---|---|
| enhance | Update the base Docker image from oven/bun:1.1.42 to oven/bun:1.2.2, possibly to leverage improvements or fixes in the newer version. |
| bugfix | Correct the lock file copy command from 'bun.lockb' to the correct file 'bun.lock', fixing a file name typo. |