### PR TITLE
feat: add GitHub CLI to Dockerfile and use staged diff in commit

### DIFF
--- a/Dockerfile.github_actions
+++ b/Dockerfile.github_actions
@@ -1,6 +1,20 @@
 FROM oven/bun:1.2.2
 
 WORKDIR /app
+
+RUN apt-get update && apt-get install -y git
+
+# Install gh
+# Official document: https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+RUN (type -p wget >/dev/null || (apt update && apt-get install wget -y)) \
+    && mkdir -p -m 755 /etc/apt/keyrings \
+    && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    && cat $out | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt update \
+    && apt install gh -y
+
 COPY package.json .
 COPY tsconfig.json .
 COPY bun.lock .

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ This command creates a pull request on GitHub.
 # create a pull request
 aica create-pr
 
-# create a pull request with --stage-only option
-aica create-pr --stage-only
+# create a pull request with --staged option
+aica create-pr --staged
 ```
 
 ### Commit Changes
@@ -102,5 +102,5 @@ This command commits changes with an AI-generated commit message.
 aica commit
 
 # only stage changes without committing
-aica commit --stage-only
+aica commit --staged
 ```

--- a/src/commands/commit-command.ts
+++ b/src/commands/commit-command.ts
@@ -21,24 +21,24 @@ export async function executeCommitCommand(
   values: any,
 ): Promise<CommitCommandResult> {
   const config = await readConfig(values.config);
-  const stageOnly = values.stageOnly;
+  const staged = values.staged;
   const dryRun = values.dryRun;
 
   const gitRoot = await getGitRepositoryRoot(process.cwd());
   if (!gitRoot) {
     throw new CommandError("Not in a git repository.");
   }
-  return executeCommit(gitRoot, config, stageOnly, dryRun);
+  return executeCommit(gitRoot, config, staged, dryRun);
 }
 
 export async function executeCommit(
   gitRoot: string,
   config: Config,
-  stageOnly: boolean,
+  staged: boolean,
   dryRun: boolean,
 ): Promise<CommitCommandResult> {
   const changes = await getAddingFilesToStage(gitRoot);
-  if (!stageOnly && changes.addingFiles.length > 0) {
+  if (!staged && changes.addingFiles.length > 0) {
     if (changes.confirmationRequiredFiles.length > 0) {
       throw new CommandError(
         "The following files are too large to add to the staging area:\n" +

--- a/src/commands/commit-command.ts
+++ b/src/commands/commit-command.ts
@@ -1,11 +1,11 @@
 import { Config, readConfig } from "@/config";
 import {
-  getGitRepositoryRoot,
-  commit,
-  getGitDiffToHead,
-  getAddingFilesToStage,
   addFilesToStage,
+  commit,
+  getAddingFilesToStage,
   getAllChangedFiles,
+  getGitDiffStageOnly,
+  getGitRepositoryRoot,
 } from "@/git";
 import { createCommitMessageFromDiff } from "./commit-message-command";
 import { CommandError } from "./error";
@@ -38,7 +38,7 @@ export async function executeCommit(
   dryRun: boolean,
 ): Promise<CommitCommandResult> {
   const changes = await getAddingFilesToStage(gitRoot);
-  if (!stageOnly) {
+  if (!stageOnly && changes.addingFiles.length > 0) {
     if (changes.confirmationRequiredFiles.length > 0) {
       throw new CommandError(
         "The following files are too large to add to the staging area:\n" +
@@ -70,7 +70,7 @@ export async function executeCommit(
   }
 
   // create a summary of the changes
-  const diff = await getGitDiffToHead(gitRoot);
+  const diff = await getGitDiffStageOnly(gitRoot);
   if (!diff) {
     throw new CommandError("No changes to commit");
   }

--- a/src/commands/create-pr-command.ts
+++ b/src/commands/create-pr-command.ts
@@ -20,7 +20,7 @@ import { executeCommit } from "./commit-command";
 export async function executeCreatePRCommand(values: any) {
   const config = await readConfig(values.config);
   const dryRun = values.dryRun;
-  const stageOnly = values.stageOnly;
+  const staged = values.staged;
 
   const gitRoot = await getGitRepositoryRoot(process.cwd());
   if (!gitRoot) {
@@ -48,7 +48,7 @@ export async function executeCreatePRCommand(values: any) {
   console.log("Got diff to remote default branch");
 
   // commit the changes
-  await executeCommit(gitRoot, config, stageOnly, dryRun);
+  await executeCommit(gitRoot, config, staged, dryRun);
 
   // create a summary of the changes
   const summary = await generateSummary(config, diff);

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,6 +1,6 @@
 export async function getGitDiffFromRemoteBranch(cwd: string, branch: string) {
   const result = Bun.spawn({
-    cmd: ["git", "diff", `origin/${branch}`],
+    cmd: ["git", "diff", "--staged", `origin/${branch}`],
     cwd,
     stdout: "pipe",
     stderr: "pipe",

--- a/src/git.ts
+++ b/src/git.ts
@@ -16,7 +16,7 @@ export async function getGitDiffFromRemoteBranch(cwd: string, branch: string) {
 
 export async function getGitDiffStageOnly(cwd: string) {
   const result = Bun.spawn({
-    cmd: ["git", "diff"],
+    cmd: ["git", "diff", "--staged"],
     cwd,
     stdout: "pipe",
     stderr: "pipe",

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,8 +66,8 @@ async function main() {
             describe: "dry run",
             type: "boolean",
           },
-          stageOnly: {
-            describe: "stage only",
+          staged: {
+            describe: "staged changes only",
             type: "boolean",
           },
         })
@@ -80,8 +80,8 @@ async function main() {
       (yargs: any) => {
         return yargs
           .options({
-            stageOnly: {
-              describe: "stage only",
+            staged: {
+              describe: "staged changes only",
               type: "boolean",
             },
             dryRun: {
@@ -102,7 +102,7 @@ async function main() {
     slack: argv.slack,
     pattern: argv.pattern,
     dryRun: argv.dryRun || false,
-    stageOnly: argv.stageOnly || false,
+    staged: argv.staged || false,
   };
 
   const subcommand = argv._[0];


### PR DESCRIPTION
| Category | Description |
|---|---|
| feature | Update the Dockerfile to install git and the GitHub CLI (gh), adding new tooling support for the Docker container. |
| enhance | Uncomment the payload log in src/actions-runner.ts to enable logging of the GitHub event payload for debugging purposes. |
| enhance | Modify commit-command.ts to add a condition checking for files in the staging area and switch from using getGitDiffToHead to getGitDiffStageOnly, thereby refining the commit process. |
| bugfix | Update the git diff command in src/git.ts by adding the '--staged' flag to correctly capture differences for staged files. |