### PR TITLE
feat: add gh cli install and update git diff to --staged

### DIFF
--- a/Dockerfile.github_actions
+++ b/Dockerfile.github_actions
@@ -1,6 +1,20 @@
 FROM oven/bun:1.2.2
 
 WORKDIR /app
+
+RUN apt-get update && apt-get install -y git
+
+# Install gh
+# Official document: https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+RUN (type -p wget >/dev/null || (apt update && apt-get install wget -y)) \
+    && mkdir -p -m 755 /etc/apt/keyrings \
+    && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    && cat $out | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt update \
+    && apt install gh -y
+
 COPY package.json .
 COPY tsconfig.json .
 COPY bun.lock .

--- a/src/commands/commit-command.ts
+++ b/src/commands/commit-command.ts
@@ -1,11 +1,11 @@
 import { Config, readConfig } from "@/config";
 import {
-  getGitRepositoryRoot,
-  commit,
-  getGitDiffToHead,
-  getAddingFilesToStage,
   addFilesToStage,
+  commit,
+  getAddingFilesToStage,
   getAllChangedFiles,
+  getGitDiffStageOnly,
+  getGitRepositoryRoot,
 } from "@/git";
 import { createCommitMessageFromDiff } from "./commit-message-command";
 import { CommandError } from "./error";
@@ -38,7 +38,7 @@ export async function executeCommit(
   dryRun: boolean,
 ): Promise<CommitCommandResult> {
   const changes = await getAddingFilesToStage(gitRoot);
-  if (!stageOnly) {
+  if (!stageOnly && changes.addingFiles.length > 0) {
     if (changes.confirmationRequiredFiles.length > 0) {
       throw new CommandError(
         "The following files are too large to add to the staging area:\n" +
@@ -70,7 +70,7 @@ export async function executeCommit(
   }
 
   // create a summary of the changes
-  const diff = await getGitDiffToHead(gitRoot);
+  const diff = await getGitDiffStageOnly(gitRoot);
   if (!diff) {
     throw new CommandError("No changes to commit");
   }

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,6 +1,6 @@
 export async function getGitDiffFromRemoteBranch(cwd: string, branch: string) {
   const result = Bun.spawn({
-    cmd: ["git", "diff", `origin/${branch}`],
+    cmd: ["git", "diff", "--staged", `origin/${branch}`],
     cwd,
     stdout: "pipe",
     stderr: "pipe",

--- a/src/git.ts
+++ b/src/git.ts
@@ -16,7 +16,7 @@ export async function getGitDiffFromRemoteBranch(cwd: string, branch: string) {
 
 export async function getGitDiffStageOnly(cwd: string) {
   const result = Bun.spawn({
-    cmd: ["git", "diff"],
+    cmd: ["git", "diff", "--staged"],
     cwd,
     stdout: "pipe",
     stderr: "pipe",


### PR DESCRIPTION
| Category | Description |
|---|---|
| enhance | Updated Dockerfile.github_actions to install git and the GitHub CLI (gh) by adding commands to update apt repositories, install wget if missing, add the official GitHub CLI keyring and repository, and install gh. |
| enhance | Modified commit-command.ts by replacing the use of getGitDiffToHead with getGitDiffStageOnly to only create a summary of staged changes, and adjusted the condition to ensure there are files in the addingFiles array before proceeding with commit logic. Also updated the imported functions to reflect these changes. |
| enhance | Updated git.ts to use the '--staged' flag in both getGitDiffFromRemoteBranch and getGitDiffStageOnly functions, ensuring that only staged changes are considered when generating diffs. |