### PR TITLE
feat: add show-config command, zod dependency and config updates

### DIFF
--- a/.github/workflows/autoreview.yaml
+++ b/.github/workflows/autoreview.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: AI Code Analyzer
-        uses: dotneet/aica@main
+        uses: dotneet/aica@v0.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/autoreview.yaml
+++ b/.github/workflows/autoreview.yaml
@@ -1,0 +1,24 @@
+name: Auto Review by AICA
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: AI Code Analyzer
+        uses: dotneet/aica@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "@orama/plugin-parsedoc": "^2.1.0",
         "@orama/plugin-secure-proxy": "^2.1.1",
         "yargs": "^17.7.2",
+        "zod": "^3.24.2",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -511,6 +512,8 @@
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@orama/plugin-data-persistence": "^2.1.1",
     "@orama/plugin-parsedoc": "^2.1.0",
     "@orama/plugin-secure-proxy": "^2.1.1",
-    "yargs": "^17.7.2"
+    "yargs": "^17.7.2",
+    "zod": "^3.24.2"
   }
 }

--- a/src/commands/show-config.ts
+++ b/src/commands/show-config.ts
@@ -1,0 +1,18 @@
+import { readConfig, defaultConfig } from "../config";
+import { z } from "zod";
+
+export const showConfigValuesSchema = z.object({
+  config: z.string().optional(),
+  default: z.boolean().optional(),
+});
+
+export type ShowConfigValues = z.infer<typeof showConfigValuesSchema>;
+
+export async function executeShowConfigCommand(values: ShowConfigValues) {
+  let config = defaultConfig;
+  if (!values.default) {
+    config = await readConfig(values.config);
+  }
+  const toml = JSON.stringify(config, null, 2);
+  console.log(toml);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -130,7 +130,16 @@ export const defaultConfig: Config = {
         "Generate one-line commit message based on given diff.",
         "Response must be less than 80 characters.",
       ],
-      user: "Generate one-line commit message based on given diff.",
+      user: `Generate one-line commit message based on given diff.
+        Use the prefix to describe the changes. Avialable prefixes: fix, feat, refactor, chore, test, docs, style, perf, ci, build, revert, merge, other
+        Examples:
+        - fix: fix the calculation logic
+        - feat: add the new command
+        - refactor: rename abc.txt to xyz.txt
+        - chore: update the dependencies
+        - test: add the test for the new command
+        - docs: update readme
+      `.replaceAll(/\n +/g, "\n"),
     },
   },
   source: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -137,10 +137,11 @@ async function main() {
       case "create-pr":
         await executeCreatePRCommand(values);
         break;
-      case "show-config":
+      case "show-config": {
         const showConfigValues = showConfigValuesSchema.parse(argv);
         await executeShowConfigCommand(showConfigValues);
         break;
+      }
       default:
         console.error("Unknown subcommand:", subcommand);
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,10 @@ import { executeSummaryDiffCommand } from "@/commands/summary-diff-command";
 import { executeCreatePRCommand } from "./commands/create-pr-command";
 import { executeCommitCommand } from "./commands/commit-command";
 import { CommandError } from "./commands/error";
+import {
+  executeShowConfigCommand,
+  showConfigValuesSchema,
+} from "./commands/show-config";
 
 async function main() {
   const argv = yargs(process.argv.slice(2))
@@ -93,6 +97,16 @@ async function main() {
           .help();
       },
     )
+    .command("show-config", "show the config", (yargs: any) => {
+      return yargs
+        .options({
+          default: {
+            describe: "show the default config",
+            type: "boolean",
+          },
+        })
+        .help();
+    })
     .demandCommand()
     .parseSync();
 
@@ -122,6 +136,10 @@ async function main() {
         break;
       case "create-pr":
         await executeCreatePRCommand(values);
+        break;
+      case "show-config":
+        const showConfigValues = showConfigValuesSchema.parse(argv);
+        await executeShowConfigCommand(showConfigValues);
         break;
       default:
         console.error("Unknown subcommand:", subcommand);


### PR DESCRIPTION
| Category | Description |
|---|---|
| enhance | Added a new GitHub workflow (.github/workflows/autoreview.yaml) to automatically review PRs and issue comments using the AICA action, improving CI/CD automation. |
| feature | Added the 'zod' dependency in bun.lock and package.json to support schema validation in the project. |
| feature | Introduced a new 'show-config' command (src/commands/show-config.ts) which reads and displays configuration, utilizing zod for validating command-line arguments. |
| enhance | Updated the default configuration in src/config.ts to include detailed instructions and examples for commit message prefixes. |
| enhance | Modified the main command registration in src/main.ts to include the 'show-config' command, integrating its parsing and execution into the CLI. |

<!-- AICA GENERATED -->
## Summary

| Category | Description |
|---|---|
| feature | Add a new GitHub workflow (.github/workflows/autoreview.yaml) for auto reviewing pull requests and issue comments using the AICA action. |
| feature | Add the 'zod' dependency to bun.lock for schema validation support. |
| feature | Add the 'zod' dependency to package.json to support validation in the new configuration command. |
| feature | Introduce a new command (src/commands/show-config.ts) to display configuration values with schema validation using 'zod'. |
| enhance | Update the default configuration message in src/config.ts with detailed commit message instruction examples and available prefixes. |
| feature | Integrate the new 'show-config' command into the main application (src/main.ts) by adding yargs command parsing and executing the show-config logic. |