### PR TITLE
refactor: rename summary-diff command to summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ aica review src/main.ts
 aica review "src/**/*.ts"
 ```
 
-### Summary Changes
+### Summary
 
 ```bash
-# summarize the diff from HEAD
-aica summary-diff
+# generate a summary of the diff from HEAD
+aica summary
 ```
 
 ### Commit Changes

--- a/src/commands/create-pr-command.ts
+++ b/src/commands/create-pr-command.ts
@@ -19,8 +19,10 @@ import { executeCommit } from "./commit-command";
 
 export async function executeCreatePRCommand(values: any) {
   const config = await readConfig(values.config);
+  const withSummary = values.withSummary;
   const dryRun = values.dryRun;
   const staged = values.staged;
+  let prBody = values.body;
 
   const gitRoot = await getGitRepositoryRoot(process.cwd());
   if (!gitRoot) {
@@ -51,11 +53,14 @@ export async function executeCreatePRCommand(values: any) {
   console.log("Got diff to remote default branch");
 
   // create a summary of the changes
-  const summary = await generateSummary(config, diff);
-  if (!summary) {
-    throw new CommandError("Failed to create a summary");
+  if (withSummary) {
+    const summary = await generateSummary(config, diff);
+    if (!summary) {
+      throw new CommandError("Failed to create a summary");
+    }
+    console.log("Generated summary");
+    prBody += "\n\n" + summary;
   }
-  console.log("Generated summary");
 
   // create a branch name
   const branchName = await createBranchName(config, diff);
@@ -89,7 +94,7 @@ export async function executeCreatePRCommand(values: any) {
       owner,
       repo,
       prTitle,
-      summary,
+      prBody,
       defaultBranch,
       branchName,
     );

--- a/src/commands/summary-diff-command.ts
+++ b/src/commands/summary-diff-command.ts
@@ -3,7 +3,7 @@ import { getGitDiffToHead } from "@/git";
 import { createLLM } from "@/llm/mod";
 import { createSummaryContext, summarizeDiff } from "@/summary";
 
-export async function executeSummaryDiffCommand(values: any) {
+export async function executeSummaryCommand(values: any) {
   const configFilePath = values.config || null;
   const config = await readConfig(configFilePath);
   const targetDir = values.dir || config.workingDirectory;

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,6 +66,16 @@ async function main() {
     .command("create-pr", "create a pull request", (yargs: any) => {
       return yargs
         .options({
+          withSummary: {
+            describe: "generate a summary of the diff from HEAD",
+            type: "boolean",
+            default: true,
+          },
+          body: {
+            describe: "body of the pull request",
+            type: "string",
+            default: "",
+          },
           dryRun: {
             describe: "dry run",
             type: "boolean",

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import yargs from "yargs";
 import { executeCommitMessageCommand } from "@/commands/commit-message-command";
 import { executeReviewCommand } from "@/commands/review-command";
 import pkg from "../package.json";
-import { executeSummaryDiffCommand } from "@/commands/summary-diff-command";
+import { executeSummaryCommand } from "@/commands/summary-diff-command";
 import { executeCreatePRCommand } from "./commands/create-pr-command";
 import { executeCommitCommand } from "./commands/commit-command";
 import { CommandError } from "./commands/error";
@@ -35,7 +35,7 @@ async function main() {
           .help();
       },
     )
-    .command("summary-diff", "summarize the diff from HEAD", (yargs: any) => {
+    .command("summary", "summarize the diff from HEAD", (yargs: any) => {
       return yargs
         .options({
           dir: {
@@ -128,8 +128,8 @@ async function main() {
       case "commit-message":
         await executeCommitMessageCommand(values);
         break;
-      case "summary-diff":
-        await executeSummaryDiffCommand(values);
+      case "summary":
+        await executeSummaryCommand(values);
         break;
       case "commit":
         await executeCommitCommand(values);


### PR DESCRIPTION
| Category | Description |
|---|---|
| docs | Updated README.md: Changed the heading from 'Summary Changes' to 'Summary' and updated command examples from 'aica summary-diff' to 'aica summary' with an improved description. |
| refactor | Renamed the command function from executeSummaryDiffCommand to executeSummaryCommand in the summary command implementation. |
| refactor | Modified main.ts to import the renamed summary command and updated the command registration and invocation from 'summary-diff' to 'summary'. |

<!-- AICA GENERATED -->
## Summary

| Category | Description |
|---|---|
| docs | Updated README.md: Renamed the 'Summary Changes' section to 'Summary' and updated the command usage from 'aica summary-diff' to 'aica summary'. |
| enhance | Modified the create-pr command to add a new option 'withSummary' and conditionally generate and append a summary to the pull request body. |
| refactor | Renamed the command function from 'executeSummaryDiffCommand' to 'executeSummaryCommand' in the summary command file and updated related imports. |
| enhance | Updated the main command registration to replace the 'summary-diff' command with the new 'summary' command, including updated options for generating summaries. |