### PR TITLE
feat: add reindex command and update database reindexing flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ export OPENAI_API_KEY=your_api_key
 export OPENAI_MODEL=o3-mini # optional
 ```
 
+## Configuration
+
+You can customize the configuration by creating a `aica.toml` file.
+
+See [aica.example.toml](aica.example.toml).
+
+aica.toml must be placed in one of the following directories.
+
+- root directory of the repository
+- ${HOME}/.config/aica/aica.toml
+- ${GITHUB_WORKSPACE}/aica.toml
+
 ## Usage
 
 ### Review
@@ -58,6 +70,13 @@ aica review src/main.ts
 
 # review the files matching the specific glob pattern
 aica review "src/**/*.ts"
+```
+
+### Reindex
+
+```bash
+# reindex the code and document databases
+aica reindex
 ```
 
 ### Summary

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import path from "path";
 import {
   CodeSearchDatabaseOrama,
+  DocumentSearchDatabaseOrama,
   KnowledgeDatabase,
 } from "./knowledge/database";
 import { Source, SourceType } from "./source";
@@ -39,8 +40,8 @@ export async function createAnalyzeContextFromConfig(
       persistentFilePath,
     );
     codeSearchDatabase = await CodeSearchDatabaseOrama.fromSettings(
-      absolutePath,
       absolutePersistentFilePath,
+      absolutePath,
       includePatterns,
       excludePatterns,
       embeddingProducer,
@@ -59,9 +60,9 @@ export async function createAnalyzeContextFromConfig(
       fs.realpathSync(wd),
       persistentFilePath,
     );
-    documentSearchDatabase = await CodeSearchDatabaseOrama.fromSettings(
-      absolutePath,
+    documentSearchDatabase = await DocumentSearchDatabaseOrama.fromSettings(
       absolutePersistentFilePath,
+      absolutePath,
       includePatterns,
       excludePatterns,
       embeddingProducer,
@@ -98,6 +99,21 @@ export function createAnalyzeContext(
     rules,
     userPrompt,
   };
+}
+
+export async function reindexAll(context: AnalyzeContext): Promise<boolean> {
+  let reindexed = false;
+  if (context.codeSearchDatabase) {
+    await context.codeSearchDatabase.reindex();
+    console.log("codeSearchDatabase reindexed");
+    reindexed = true;
+  }
+  if (context.documentSearchDatabase) {
+    await context.documentSearchDatabase.reindex();
+    console.log("documentSearchDatabase reindexed");
+    reindexed = true;
+  }
+  return reindexed;
 }
 
 export type Issue = {

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -34,8 +34,9 @@ export async function createAnalyzeContextFromConfig(
     const { directory, persistentFilePath, includePatterns, excludePatterns } =
       config.knowledge.codeSearch;
     const absolutePath = fs.realpathSync(path.join(wd, directory));
-    const absolutePersistentFilePath = fs.realpathSync(
-      path.join(wd, persistentFilePath),
+    const absolutePersistentFilePath = path.join(
+      fs.realpathSync(wd),
+      persistentFilePath,
     );
     codeSearchDatabase = await CodeSearchDatabaseOrama.fromSettings(
       absolutePath,
@@ -54,8 +55,9 @@ export async function createAnalyzeContextFromConfig(
     const { directory, persistentFilePath, includePatterns, excludePatterns } =
       config.knowledge.documentSearch;
     const absolutePath = fs.realpathSync(path.join(wd, directory));
-    const absolutePersistentFilePath = fs.realpathSync(
-      path.join(wd, persistentFilePath),
+    const absolutePersistentFilePath = path.join(
+      fs.realpathSync(wd),
+      persistentFilePath,
     );
     documentSearchDatabase = await CodeSearchDatabaseOrama.fromSettings(
       absolutePath,

--- a/src/commands/index-command.ts
+++ b/src/commands/index-command.ts
@@ -1,0 +1,13 @@
+import { createAnalyzeContextFromConfig, reindexAll } from "@/analyze";
+import { readConfig } from "@/config";
+
+export async function executeIndexCommand(values: any) {
+  const config = await readConfig(values.config);
+  const context = await createAnalyzeContextFromConfig(config);
+  const reindexed = await reindexAll(context);
+  if (reindexed) {
+    console.log("Reindexed all databases");
+  } else {
+    console.log("No databases to reindex");
+  }
+}

--- a/src/embedding/embedding.ts
+++ b/src/embedding/embedding.ts
@@ -1,8 +1,15 @@
 export class EmbeddingProducer {
   constructor(
     private readonly openAiApiKey: string,
-    private readonly embeddingModel: string
-  ) {}
+    private readonly embeddingModel: string,
+  ) {
+    if (!this.openAiApiKey) {
+      throw new Error("OPENAI_API_KEY is not set");
+    }
+    if (!this.embeddingModel) {
+      throw new Error("EMBEDDING_MODEL is not set");
+    }
+  }
 
   async getEmbedding(text: string) {
     const response = await fetch("https://api.openai.com/v1/embeddings", {
@@ -13,6 +20,10 @@ export class EmbeddingProducer {
       },
       body: JSON.stringify({ model: this.embeddingModel, input: text }),
     });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Failed to get embedding: ${text}`);
+    }
     const { data } = await response.json();
     return data[0].embedding;
   }

--- a/src/embedding/factory.ts
+++ b/src/embedding/factory.ts
@@ -4,7 +4,7 @@ import { EmbeddingProducer } from "./embedding";
 export function createEmbeddingProducer(settings: EmbeddingConfig) {
   const { provider, openai } = settings;
   if (provider === "openai") {
-    return new EmbeddingProducer(openai.model, openai.apiKey);
+    return new EmbeddingProducer(openai.apiKey, openai.model);
   } else {
     throw new Error(`Unknown embedding provider: ${provider}`);
   }

--- a/src/knowledge/database.ts
+++ b/src/knowledge/database.ts
@@ -16,6 +16,7 @@ export interface KnowledgeDatabase {
     includePatterns: string[],
     excludePatterns: string[],
   ): Promise<void>;
+  reindex(): Promise<void>;
   insert(path: string, content: string): Promise<void>;
   search(
     content: string,
@@ -33,31 +34,58 @@ export class CodeSearchDatabaseOrama implements KnowledgeDatabase {
 
   constructor(
     private db: Orama<typeof CodeSearchDatabaseOrama.schema>,
+    private persistentFilePath: string,
+    private directory: string,
+    private includePatterns: string[],
+    private excludePatterns: string[],
     private embeddingProducer: EmbeddingProducer,
   ) {}
 
-  static async create(embeddingProducer: EmbeddingProducer) {
+  static async create(
+    persistentFilePath: string,
+    directory: string,
+    includePatterns: string[],
+    excludePatterns: string[],
+    embeddingProducer: EmbeddingProducer,
+  ) {
     const db: Orama<typeof CodeSearchDatabaseOrama.schema> = await create({
       schema: CodeSearchDatabaseOrama.schema,
     });
-    return new CodeSearchDatabaseOrama(db, embeddingProducer);
+    return new CodeSearchDatabaseOrama(
+      db,
+      persistentFilePath,
+      directory,
+      includePatterns,
+      excludePatterns,
+      embeddingProducer,
+    );
   }
 
   static async load(
-    path: string,
+    persistentFilePath: string,
+    directory: string,
+    includePatterns: string[],
+    excludePatterns: string[],
     embeddingProducer: EmbeddingProducer,
   ): Promise<CodeSearchDatabaseOrama> {
-    const JSONIndex = fs.readFileSync(path, "utf8");
+    const JSONIndex = fs.readFileSync(persistentFilePath, "utf8");
     const db: Orama<typeof CodeSearchDatabaseOrama.schema> = await restore(
       "json",
       JSONIndex,
     );
-    return new CodeSearchDatabaseOrama(db, embeddingProducer);
+    return new CodeSearchDatabaseOrama(
+      db,
+      persistentFilePath,
+      directory,
+      includePatterns,
+      excludePatterns,
+      embeddingProducer,
+    );
   }
 
   static async fromSettings(
-    directory: string,
     persistentFilePath: string,
+    directory: string,
     includePatterns: string[],
     excludePatterns: string[],
     embeddingProducer: EmbeddingProducer,
@@ -65,11 +93,20 @@ export class CodeSearchDatabaseOrama implements KnowledgeDatabase {
     if (fs.existsSync(persistentFilePath)) {
       return await CodeSearchDatabaseOrama.load(
         persistentFilePath,
+        directory,
+        includePatterns,
+        excludePatterns,
         embeddingProducer,
       );
     } else {
-      const db = await CodeSearchDatabaseOrama.create(embeddingProducer);
-      await db.populate(directory, includePatterns, excludePatterns);
+      const db = await CodeSearchDatabaseOrama.create(
+        persistentFilePath,
+        directory,
+        includePatterns,
+        excludePatterns,
+        embeddingProducer,
+      );
+      await db.populate();
       if (persistentFilePath) {
         await db.save(persistentFilePath);
       } else {
@@ -81,22 +118,29 @@ export class CodeSearchDatabaseOrama implements KnowledgeDatabase {
     }
   }
 
-  async populate(
-    directory: string,
-    includePatterns: string[],
-    excludePatterns: string[],
-  ): Promise<void> {
-    const excludeGlobs = excludePatterns.map((pattern) => new Glob(pattern));
-    for (const includePattern of includePatterns) {
+  async populate(): Promise<void> {
+    const excludeGlobs = this.excludePatterns.map(
+      (pattern) => new Glob(pattern),
+    );
+    for (const includePattern of this.includePatterns) {
       const glob = new Glob(includePattern);
-      for await (const file of glob.scan(directory)) {
+      for await (const file of glob.scan(this.directory)) {
         if (excludeGlobs.some((excludeGlob) => excludeGlob.match(file))) {
           continue;
         }
-        const absPath = path.join(directory, file);
+        const absPath = path.join(this.directory, file);
         await this.insert(absPath, fs.readFileSync(absPath, "utf8"));
       }
     }
+  }
+
+  async reindex(): Promise<void> {
+    const db: Orama<typeof CodeSearchDatabaseOrama.schema> = await create({
+      schema: CodeSearchDatabaseOrama.schema,
+    });
+    this.db = db;
+    await this.populate();
+    await this.save(this.persistentFilePath);
   }
 
   async insert(path: string, content: string) {
@@ -147,31 +191,58 @@ export class DocumentSearchDatabaseOrama implements KnowledgeDatabase {
 
   constructor(
     private db: Orama<typeof DocumentSearchDatabaseOrama.schema>,
+    private persistentFilePath: string,
+    private directory: string,
+    private includePatterns: string[],
+    private excludePatterns: string[],
     private embeddingProducer: EmbeddingProducer,
   ) {}
 
-  static async create(embeddingProducer: EmbeddingProducer) {
+  static async create(
+    persistentFilePath: string,
+    directory: string,
+    includePatterns: string[],
+    excludePatterns: string[],
+    embeddingProducer: EmbeddingProducer,
+  ) {
     const db: Orama<typeof DocumentSearchDatabaseOrama.schema> = await create({
       schema: DocumentSearchDatabaseOrama.schema,
     });
-    return new DocumentSearchDatabaseOrama(db, embeddingProducer);
+    return new DocumentSearchDatabaseOrama(
+      db,
+      persistentFilePath,
+      directory,
+      includePatterns,
+      excludePatterns,
+      embeddingProducer,
+    );
   }
 
   static async load(
-    path: string,
+    persistentFilePath: string,
+    directory: string,
+    includePatterns: string[],
+    excludePatterns: string[],
     embeddingProducer: EmbeddingProducer,
   ): Promise<DocumentSearchDatabaseOrama> {
-    const JSONIndex = fs.readFileSync(path, "utf8");
+    const JSONIndex = fs.readFileSync(persistentFilePath, "utf8");
     const db: Orama<typeof DocumentSearchDatabaseOrama.schema> = await restore(
       "json",
       JSONIndex,
     );
-    return new DocumentSearchDatabaseOrama(db, embeddingProducer);
+    return new DocumentSearchDatabaseOrama(
+      db,
+      persistentFilePath,
+      directory,
+      includePatterns,
+      excludePatterns,
+      embeddingProducer,
+    );
   }
 
   static async fromSettings(
-    directory: string,
     persistentFilePath: string,
+    directory: string,
     includePatterns: string[],
     excludePatterns: string[],
     embeddingProducer: EmbeddingProducer,
@@ -179,11 +250,20 @@ export class DocumentSearchDatabaseOrama implements KnowledgeDatabase {
     if (fs.existsSync(persistentFilePath)) {
       return await DocumentSearchDatabaseOrama.load(
         persistentFilePath,
+        directory,
+        includePatterns,
+        excludePatterns,
         embeddingProducer,
       );
     } else {
-      const db = await DocumentSearchDatabaseOrama.create(embeddingProducer);
-      await db.populate(directory, includePatterns, excludePatterns);
+      const db = await DocumentSearchDatabaseOrama.create(
+        persistentFilePath,
+        directory,
+        includePatterns,
+        excludePatterns,
+        embeddingProducer,
+      );
+      await db.populate();
       if (persistentFilePath) {
         await db.save(persistentFilePath);
         console.warn(
@@ -195,22 +275,29 @@ export class DocumentSearchDatabaseOrama implements KnowledgeDatabase {
     }
   }
 
-  async populate(
-    directory: string,
-    includePatterns: string[],
-    excludePatterns: string[],
-  ): Promise<void> {
-    const excludeGlobs = excludePatterns.map((pattern) => new Glob(pattern));
-    for (const includePattern of includePatterns) {
+  async populate(): Promise<void> {
+    const excludeGlobs = this.excludePatterns.map(
+      (pattern) => new Glob(pattern),
+    );
+    for (const includePattern of this.includePatterns) {
       const glob = new Glob(includePattern);
-      for await (const file of glob.scan(directory)) {
+      for await (const file of glob.scan(this.directory)) {
         if (excludeGlobs.some((excludeGlob) => excludeGlob.match(file))) {
           continue;
         }
-        const absPath = path.join(directory, file);
+        const absPath = path.join(this.directory, file);
         await this.insert(absPath, fs.readFileSync(absPath, "utf8"));
       }
     }
+  }
+
+  async reindex(): Promise<void> {
+    const db: Orama<typeof DocumentSearchDatabaseOrama.schema> = await create({
+      schema: DocumentSearchDatabaseOrama.schema,
+    });
+    this.db = db;
+    await this.populate();
+    await this.save(this.persistentFilePath);
   }
 
   async insert(path: string, content: string) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import {
   executeShowConfigCommand,
   showConfigValuesSchema,
 } from "./commands/show-config";
+import { executeIndexCommand as executeReindexCommand } from "./commands/index-command";
 
 async function main() {
   const argv = yargs(process.argv.slice(2))
@@ -62,6 +63,9 @@ async function main() {
           describe: "search pattern",
           type: "string",
         });
+    })
+    .command("index", "index the code and document", (yargs: any) => {
+      return yargs.strict().help();
     })
     .command("create-pr", "create a pull request", (yargs: any) => {
       return yargs
@@ -146,6 +150,9 @@ async function main() {
         break;
       case "create-pr":
         await executeCreatePRCommand(values);
+        break;
+      case "reindex":
+        await executeReindexCommand(values);
         break;
       case "show-config": {
         const showConfigValues = showConfigValuesSchema.parse(argv);


### PR DESCRIPTION
<!-- AICA GENERATED -->
## Summary

| Category | Description |
|---|---|
| docs | Updated the README.md to include instructions for creating a configuration file (aica.toml) and added a usage section for the new 'Reindex' command. |
| feature | Introduced a new CLI command (via commands/index-command.ts and main.ts) that supports reindexing both code and document databases by invoking the new reindexAll function. |
| enhance | Refactored the way persistent file paths are computed in createAnalyzeContextFromConfig by changing the order of path resolution to improve flexibility and consistency in both code and document search databases. |
| bugfix | Fixed the parameter order in the embedding producer factory by swapping arguments to correctly pass the API key and the model to the EmbeddingProducer constructor. |
| enhance | Enhanced the CodeSearchDatabaseOrama and DocumentSearchDatabaseOrama classes by adding instance properties for persistent file path, directory, include/exclude patterns and implementing a new reindex() method that rebuilds, repopulates, and saves the databases. |
| enhance | Added error handling in the EmbeddingProducer class to validate required parameters (OPENAI_API_KEY and EMBEDDING_MODEL) and to check the API response, throwing an error if the embedding request fails. |