### PR TITLE
feat: add reindex command, config docs, and schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ export OPENAI_API_KEY=your_api_key
 export OPENAI_MODEL=o3-mini # optional
 ```
 
+## Configuration
+
+You can customize the configuration by creating a `aica.toml` file.
+
+See [aica.example.toml](aica.example.toml).
+
+aica.toml must be placed in one of the following directories.
+
+- root directory of the repository
+- ${HOME}/.config/aica/aica.toml
+- ${GITHUB_WORKSPACE}/aica.toml
+
 ## Usage
 
 ### Review
@@ -58,6 +70,13 @@ aica review src/main.ts
 
 # review the files matching the specific glob pattern
 aica review "src/**/*.ts"
+```
+
+### Reindex
+
+```bash
+# reindex the code and document databases
+aica reindex
 ```
 
 ### Summary

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import path from "path";
 import {
   CodeSearchDatabaseOrama,
+  DocumentSearchDatabaseOrama,
   KnowledgeDatabase,
 } from "./knowledge/database";
 import { Source, SourceType } from "./source";
@@ -39,8 +40,8 @@ export async function createAnalyzeContextFromConfig(
       persistentFilePath,
     );
     codeSearchDatabase = await CodeSearchDatabaseOrama.fromSettings(
-      absolutePath,
       absolutePersistentFilePath,
+      absolutePath,
       includePatterns,
       excludePatterns,
       embeddingProducer,
@@ -59,9 +60,9 @@ export async function createAnalyzeContextFromConfig(
       fs.realpathSync(wd),
       persistentFilePath,
     );
-    documentSearchDatabase = await CodeSearchDatabaseOrama.fromSettings(
-      absolutePath,
+    documentSearchDatabase = await DocumentSearchDatabaseOrama.fromSettings(
       absolutePersistentFilePath,
+      absolutePath,
       includePatterns,
       excludePatterns,
       embeddingProducer,
@@ -98,6 +99,21 @@ export function createAnalyzeContext(
     rules,
     userPrompt,
   };
+}
+
+export async function reindexAll(context: AnalyzeContext): Promise<boolean> {
+  let reindexed = false;
+  if (context.codeSearchDatabase) {
+    await context.codeSearchDatabase.reindex();
+    console.log("codeSearchDatabase reindexed");
+    reindexed = true;
+  }
+  if (context.documentSearchDatabase) {
+    await context.documentSearchDatabase.reindex();
+    console.log("documentSearchDatabase reindexed");
+    reindexed = true;
+  }
+  return reindexed;
 }
 
 export type Issue = {

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -34,8 +34,9 @@ export async function createAnalyzeContextFromConfig(
     const { directory, persistentFilePath, includePatterns, excludePatterns } =
       config.knowledge.codeSearch;
     const absolutePath = fs.realpathSync(path.join(wd, directory));
-    const absolutePersistentFilePath = fs.realpathSync(
-      path.join(wd, persistentFilePath),
+    const absolutePersistentFilePath = path.join(
+      fs.realpathSync(wd),
+      persistentFilePath,
     );
     codeSearchDatabase = await CodeSearchDatabaseOrama.fromSettings(
       absolutePath,
@@ -54,8 +55,9 @@ export async function createAnalyzeContextFromConfig(
     const { directory, persistentFilePath, includePatterns, excludePatterns } =
       config.knowledge.documentSearch;
     const absolutePath = fs.realpathSync(path.join(wd, directory));
-    const absolutePersistentFilePath = fs.realpathSync(
-      path.join(wd, persistentFilePath),
+    const absolutePersistentFilePath = path.join(
+      fs.realpathSync(wd),
+      persistentFilePath,
     );
     documentSearchDatabase = await CodeSearchDatabaseOrama.fromSettings(
       absolutePath,

--- a/src/commands/create-pr-command.ts
+++ b/src/commands/create-pr-command.ts
@@ -16,8 +16,19 @@ import { createCommitMessageFromDiff } from "./commit-message-command";
 import { createBranchName } from "@/github/branch";
 import { CommandError } from "./error";
 import { executeCommit } from "./commit-command";
+import { z } from "zod";
 
-export async function executeCreatePRCommand(values: any) {
+export const createPRValuesSchema = z.object({
+  config: z.string().optional(),
+  withSummary: z.boolean().optional(),
+  dryRun: z.boolean().optional(),
+  staged: z.boolean().optional(),
+  body: z.string().optional(),
+});
+
+export type CreatePRValues = z.infer<typeof createPRValuesSchema>;
+
+export async function executeCreatePRCommand(values: CreatePRValues) {
   const config = await readConfig(values.config);
   const withSummary = values.withSummary;
   const dryRun = values.dryRun;

--- a/src/commands/create-pr-command.ts
+++ b/src/commands/create-pr-command.ts
@@ -20,10 +20,10 @@ import { z } from "zod";
 
 export const createPRValuesSchema = z.object({
   config: z.string().optional(),
-  withSummary: z.boolean().optional(),
-  dryRun: z.boolean().optional(),
-  staged: z.boolean().optional(),
-  body: z.string().optional(),
+  withSummary: z.boolean().default(true),
+  dryRun: z.boolean().default(false),
+  staged: z.boolean().default(false),
+  body: z.string().default(""),
 });
 
 export type CreatePRValues = z.infer<typeof createPRValuesSchema>;
@@ -70,7 +70,11 @@ export async function executeCreatePRCommand(values: CreatePRValues) {
       throw new CommandError("Failed to create a summary");
     }
     console.log("Generated summary");
-    prBody += "\n\n" + summary;
+    if (prBody) {
+      prBody += "\n\n" + summary;
+    } else {
+      prBody = summary;
+    }
   }
 
   // create a branch name

--- a/src/commands/index-command.ts
+++ b/src/commands/index-command.ts
@@ -1,0 +1,13 @@
+import { createAnalyzeContextFromConfig, reindexAll } from "@/analyze";
+import { readConfig } from "@/config";
+
+export async function executeIndexCommand(values: any) {
+  const config = await readConfig(values.config);
+  const context = await createAnalyzeContextFromConfig(config);
+  const reindexed = await reindexAll(context);
+  if (reindexed) {
+    console.log("Reindexed all databases");
+  } else {
+    console.log("No databases to reindex");
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,7 @@ export type LLMConfig = {
   };
 };
 
-export type EmbeddingProvider = "openai";
+export type EmbeddingProvider = "openai" | "stub";
 
 export type EmbeddingConfig = {
   provider: EmbeddingProvider;

--- a/src/embedding/embedding.ts
+++ b/src/embedding/embedding.ts
@@ -1,4 +1,8 @@
-export class EmbeddingProducer {
+export interface EmbeddingProducer {
+  getEmbedding(text: string): Promise<number[]>;
+}
+
+export class OpenAIEmbeddingProducer implements EmbeddingProducer {
   constructor(
     private readonly openAiApiKey: string,
     private readonly embeddingModel: string,
@@ -11,7 +15,7 @@ export class EmbeddingProducer {
     }
   }
 
-  async getEmbedding(text: string) {
+  async getEmbedding(text: string): Promise<number[]> {
     const response = await fetch("https://api.openai.com/v1/embeddings", {
       method: "POST",
       headers: {
@@ -26,5 +30,11 @@ export class EmbeddingProducer {
     }
     const { data } = await response.json();
     return data[0].embedding;
+  }
+}
+
+export class EmbeddingProducerStub implements EmbeddingProducer {
+  async getEmbedding(text: string): Promise<number[]> {
+    return [0.1, 0.2, 0.3];
   }
 }

--- a/src/embedding/embedding.ts
+++ b/src/embedding/embedding.ts
@@ -1,8 +1,15 @@
 export class EmbeddingProducer {
   constructor(
     private readonly openAiApiKey: string,
-    private readonly embeddingModel: string
-  ) {}
+    private readonly embeddingModel: string,
+  ) {
+    if (!this.openAiApiKey) {
+      throw new Error("OPENAI_API_KEY is not set");
+    }
+    if (!this.embeddingModel) {
+      throw new Error("EMBEDDING_MODEL is not set");
+    }
+  }
 
   async getEmbedding(text: string) {
     const response = await fetch("https://api.openai.com/v1/embeddings", {
@@ -13,6 +20,10 @@ export class EmbeddingProducer {
       },
       body: JSON.stringify({ model: this.embeddingModel, input: text }),
     });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Failed to get embedding: ${text}`);
+    }
     const { data } = await response.json();
     return data[0].embedding;
   }

--- a/src/embedding/factory.ts
+++ b/src/embedding/factory.ts
@@ -1,10 +1,18 @@
 import { EmbeddingConfig } from "@/config";
-import { EmbeddingProducer } from "./embedding";
+import {
+  EmbeddingProducer,
+  EmbeddingProducerStub,
+  OpenAIEmbeddingProducer,
+} from "./embedding";
 
-export function createEmbeddingProducer(settings: EmbeddingConfig) {
+export function createEmbeddingProducer(
+  settings: EmbeddingConfig,
+): EmbeddingProducer {
   const { provider, openai } = settings;
   if (provider === "openai") {
-    return new EmbeddingProducer(openai.apiKey, openai.model);
+    return new OpenAIEmbeddingProducer(openai.apiKey, openai.model);
+  } else if (provider === "stub") {
+    return new EmbeddingProducerStub();
   } else {
     throw new Error(`Unknown embedding provider: ${provider}`);
   }

--- a/src/embedding/factory.ts
+++ b/src/embedding/factory.ts
@@ -4,7 +4,7 @@ import { EmbeddingProducer } from "./embedding";
 export function createEmbeddingProducer(settings: EmbeddingConfig) {
   const { provider, openai } = settings;
   if (provider === "openai") {
-    return new EmbeddingProducer(openai.model, openai.apiKey);
+    return new EmbeddingProducer(openai.apiKey, openai.model);
   } else {
     throw new Error(`Unknown embedding provider: ${provider}`);
   }

--- a/src/github/review.test.ts
+++ b/src/github/review.test.ts
@@ -15,6 +15,9 @@ describe("generateReview", () => {
         provider: "stub",
         stub: { response: '{"issues": [{"description": "Mock issue"}]}' },
       },
+      embedding: {
+        provider: "stub",
+      },
     });
     const result = await generateReview(config, mockDiffString);
     expect(result).toContain("Mock issue");
@@ -25,6 +28,9 @@ describe("generateReview", () => {
       llm: {
         provider: "stub",
         stub: { response: '{"issues": []}' },
+      },
+      embedding: {
+        provider: "stub",
       },
     });
     const result = await generateReview(config, mockDiffString);

--- a/src/knowledge/database.ts
+++ b/src/knowledge/database.ts
@@ -16,6 +16,7 @@ export interface KnowledgeDatabase {
     includePatterns: string[],
     excludePatterns: string[],
   ): Promise<void>;
+  reindex(): Promise<void>;
   insert(path: string, content: string): Promise<void>;
   search(
     content: string,
@@ -33,31 +34,58 @@ export class CodeSearchDatabaseOrama implements KnowledgeDatabase {
 
   constructor(
     private db: Orama<typeof CodeSearchDatabaseOrama.schema>,
+    private persistentFilePath: string,
+    private directory: string,
+    private includePatterns: string[],
+    private excludePatterns: string[],
     private embeddingProducer: EmbeddingProducer,
   ) {}
 
-  static async create(embeddingProducer: EmbeddingProducer) {
+  static async create(
+    persistentFilePath: string,
+    directory: string,
+    includePatterns: string[],
+    excludePatterns: string[],
+    embeddingProducer: EmbeddingProducer,
+  ) {
     const db: Orama<typeof CodeSearchDatabaseOrama.schema> = await create({
       schema: CodeSearchDatabaseOrama.schema,
     });
-    return new CodeSearchDatabaseOrama(db, embeddingProducer);
+    return new CodeSearchDatabaseOrama(
+      db,
+      persistentFilePath,
+      directory,
+      includePatterns,
+      excludePatterns,
+      embeddingProducer,
+    );
   }
 
   static async load(
-    path: string,
+    persistentFilePath: string,
+    directory: string,
+    includePatterns: string[],
+    excludePatterns: string[],
     embeddingProducer: EmbeddingProducer,
   ): Promise<CodeSearchDatabaseOrama> {
-    const JSONIndex = fs.readFileSync(path, "utf8");
+    const JSONIndex = fs.readFileSync(persistentFilePath, "utf8");
     const db: Orama<typeof CodeSearchDatabaseOrama.schema> = await restore(
       "json",
       JSONIndex,
     );
-    return new CodeSearchDatabaseOrama(db, embeddingProducer);
+    return new CodeSearchDatabaseOrama(
+      db,
+      persistentFilePath,
+      directory,
+      includePatterns,
+      excludePatterns,
+      embeddingProducer,
+    );
   }
 
   static async fromSettings(
-    directory: string,
     persistentFilePath: string,
+    directory: string,
     includePatterns: string[],
     excludePatterns: string[],
     embeddingProducer: EmbeddingProducer,
@@ -65,11 +93,20 @@ export class CodeSearchDatabaseOrama implements KnowledgeDatabase {
     if (fs.existsSync(persistentFilePath)) {
       return await CodeSearchDatabaseOrama.load(
         persistentFilePath,
+        directory,
+        includePatterns,
+        excludePatterns,
         embeddingProducer,
       );
     } else {
-      const db = await CodeSearchDatabaseOrama.create(embeddingProducer);
-      await db.populate(directory, includePatterns, excludePatterns);
+      const db = await CodeSearchDatabaseOrama.create(
+        persistentFilePath,
+        directory,
+        includePatterns,
+        excludePatterns,
+        embeddingProducer,
+      );
+      await db.populate();
       if (persistentFilePath) {
         await db.save(persistentFilePath);
       } else {
@@ -81,22 +118,29 @@ export class CodeSearchDatabaseOrama implements KnowledgeDatabase {
     }
   }
 
-  async populate(
-    directory: string,
-    includePatterns: string[],
-    excludePatterns: string[],
-  ): Promise<void> {
-    const excludeGlobs = excludePatterns.map((pattern) => new Glob(pattern));
-    for (const includePattern of includePatterns) {
+  async populate(): Promise<void> {
+    const excludeGlobs = this.excludePatterns.map(
+      (pattern) => new Glob(pattern),
+    );
+    for (const includePattern of this.includePatterns) {
       const glob = new Glob(includePattern);
-      for await (const file of glob.scan(directory)) {
+      for await (const file of glob.scan(this.directory)) {
         if (excludeGlobs.some((excludeGlob) => excludeGlob.match(file))) {
           continue;
         }
-        const absPath = path.join(directory, file);
+        const absPath = path.join(this.directory, file);
         await this.insert(absPath, fs.readFileSync(absPath, "utf8"));
       }
     }
+  }
+
+  async reindex(): Promise<void> {
+    const db: Orama<typeof CodeSearchDatabaseOrama.schema> = await create({
+      schema: CodeSearchDatabaseOrama.schema,
+    });
+    this.db = db;
+    await this.populate();
+    await this.save(this.persistentFilePath);
   }
 
   async insert(path: string, content: string) {
@@ -147,31 +191,58 @@ export class DocumentSearchDatabaseOrama implements KnowledgeDatabase {
 
   constructor(
     private db: Orama<typeof DocumentSearchDatabaseOrama.schema>,
+    private persistentFilePath: string,
+    private directory: string,
+    private includePatterns: string[],
+    private excludePatterns: string[],
     private embeddingProducer: EmbeddingProducer,
   ) {}
 
-  static async create(embeddingProducer: EmbeddingProducer) {
+  static async create(
+    persistentFilePath: string,
+    directory: string,
+    includePatterns: string[],
+    excludePatterns: string[],
+    embeddingProducer: EmbeddingProducer,
+  ) {
     const db: Orama<typeof DocumentSearchDatabaseOrama.schema> = await create({
       schema: DocumentSearchDatabaseOrama.schema,
     });
-    return new DocumentSearchDatabaseOrama(db, embeddingProducer);
+    return new DocumentSearchDatabaseOrama(
+      db,
+      persistentFilePath,
+      directory,
+      includePatterns,
+      excludePatterns,
+      embeddingProducer,
+    );
   }
 
   static async load(
-    path: string,
+    persistentFilePath: string,
+    directory: string,
+    includePatterns: string[],
+    excludePatterns: string[],
     embeddingProducer: EmbeddingProducer,
   ): Promise<DocumentSearchDatabaseOrama> {
-    const JSONIndex = fs.readFileSync(path, "utf8");
+    const JSONIndex = fs.readFileSync(persistentFilePath, "utf8");
     const db: Orama<typeof DocumentSearchDatabaseOrama.schema> = await restore(
       "json",
       JSONIndex,
     );
-    return new DocumentSearchDatabaseOrama(db, embeddingProducer);
+    return new DocumentSearchDatabaseOrama(
+      db,
+      persistentFilePath,
+      directory,
+      includePatterns,
+      excludePatterns,
+      embeddingProducer,
+    );
   }
 
   static async fromSettings(
-    directory: string,
     persistentFilePath: string,
+    directory: string,
     includePatterns: string[],
     excludePatterns: string[],
     embeddingProducer: EmbeddingProducer,
@@ -179,11 +250,20 @@ export class DocumentSearchDatabaseOrama implements KnowledgeDatabase {
     if (fs.existsSync(persistentFilePath)) {
       return await DocumentSearchDatabaseOrama.load(
         persistentFilePath,
+        directory,
+        includePatterns,
+        excludePatterns,
         embeddingProducer,
       );
     } else {
-      const db = await DocumentSearchDatabaseOrama.create(embeddingProducer);
-      await db.populate(directory, includePatterns, excludePatterns);
+      const db = await DocumentSearchDatabaseOrama.create(
+        persistentFilePath,
+        directory,
+        includePatterns,
+        excludePatterns,
+        embeddingProducer,
+      );
+      await db.populate();
       if (persistentFilePath) {
         await db.save(persistentFilePath);
         console.warn(
@@ -195,22 +275,29 @@ export class DocumentSearchDatabaseOrama implements KnowledgeDatabase {
     }
   }
 
-  async populate(
-    directory: string,
-    includePatterns: string[],
-    excludePatterns: string[],
-  ): Promise<void> {
-    const excludeGlobs = excludePatterns.map((pattern) => new Glob(pattern));
-    for (const includePattern of includePatterns) {
+  async populate(): Promise<void> {
+    const excludeGlobs = this.excludePatterns.map(
+      (pattern) => new Glob(pattern),
+    );
+    for (const includePattern of this.includePatterns) {
       const glob = new Glob(includePattern);
-      for await (const file of glob.scan(directory)) {
+      for await (const file of glob.scan(this.directory)) {
         if (excludeGlobs.some((excludeGlob) => excludeGlob.match(file))) {
           continue;
         }
-        const absPath = path.join(directory, file);
+        const absPath = path.join(this.directory, file);
         await this.insert(absPath, fs.readFileSync(absPath, "utf8"));
       }
     }
+  }
+
+  async reindex(): Promise<void> {
+    const db: Orama<typeof DocumentSearchDatabaseOrama.schema> = await create({
+      schema: DocumentSearchDatabaseOrama.schema,
+    });
+    this.db = db;
+    await this.populate();
+    await this.save(this.persistentFilePath);
   }
 
   async insert(path: string, content: string) {

--- a/src/knowledge/database.ts
+++ b/src/knowledge/database.ts
@@ -313,7 +313,9 @@ export class DocumentSearchDatabaseOrama implements KnowledgeDatabase {
     content: string,
     limit: number = 3,
   ): Promise<{ content: string; path: string }[]> {
-    const embedding = await this.embeddingProducer.getEmbedding(content);
+    const embedding: number[] = await this.embeddingProducer.getEmbedding(
+      content,
+    );
     const result = await search(this.db, {
       mode: "vector",
       vector: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import {
   executeShowConfigCommand,
   showConfigValuesSchema,
 } from "./commands/show-config";
+import { executeIndexCommand as executeReindexCommand } from "./commands/index-command";
 
 async function main() {
   const argv = yargs(process.argv.slice(2))
@@ -62,6 +63,9 @@ async function main() {
           describe: "search pattern",
           type: "string",
         });
+    })
+    .command("index", "index the code and document", (yargs: any) => {
+      return yargs.strict().help();
     })
     .command("create-pr", "create a pull request", (yargs: any) => {
       return yargs
@@ -146,6 +150,9 @@ async function main() {
         break;
       case "create-pr":
         await executeCreatePRCommand(values);
+        break;
+      case "reindex":
+        await executeReindexCommand(values);
         break;
       case "show-config": {
         const showConfigValues = showConfigValuesSchema.parse(argv);

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,10 @@ import { executeCommitMessageCommand } from "@/commands/commit-message-command";
 import { executeReviewCommand } from "@/commands/review-command";
 import pkg from "../package.json";
 import { executeSummaryCommand } from "@/commands/summary-diff-command";
-import { executeCreatePRCommand } from "./commands/create-pr-command";
+import {
+  createPRValuesSchema,
+  executeCreatePRCommand,
+} from "./commands/create-pr-command";
 import { executeCommitCommand } from "./commands/commit-command";
 import { CommandError } from "./commands/error";
 import {
@@ -149,7 +152,8 @@ async function main() {
         await executeCommitCommand(values);
         break;
       case "create-pr":
-        await executeCreatePRCommand(values);
+        const createPRValues = createPRValuesSchema.parse(values);
+        await executeCreatePRCommand(createPRValues);
         break;
       case "reindex":
         await executeReindexCommand(values);


### PR DESCRIPTION
<!-- AICA GENERATED -->
## Summary

| Category | Description |
|---|---|
| docs | Updated README.md with a new 'Configuration' section for creating and placing aica.toml, and added usage instructions for the 'Reindex' command. |
| feature | Introduced a new reindex functionality in src/analyze.ts by adding the reindexAll function to reindex both code and document databases. |
| enhance | Improved file path resolution in src/analyze.ts by replacing fs.realpathSync usage within path.join for both persistent file path settings. |
| enhance | Enhanced the create PR command in src/commands/create-pr-command.ts by adding Zod schema validation for command arguments and refining how summary content is appended to the PR body. |
| feature | Added a new command in src/commands/index-command.ts to allow indexing (reindexing) of code and document databases. |
| refactor | Expanded the EmbeddingProvider type in src/config.ts to support a 'stub' provider alongside 'openai' for embedding configurations. |
| refactor | Refactored embedding module in src/embedding/embedding.ts by converting EmbeddingProducer into an interface and adding two new classes (OpenAIEmbeddingProducer and EmbeddingProducerStub) with improved error handling. |
| refactor | Updated the embedding factory in src/embedding/factory.ts to adopt the new embedding producer classes and support the stub provider. |
| bugfix | Modified tests in src/github/review.test.ts to include the embedding configuration, ensuring test coverage with the stub provider. |
| enhance | Refactored database classes in src/knowledge/database.ts for both code and document search by adjusting constructor parameters, simplifying the populate method, and adding a reindex method to rebuild and persist the database. |
| enhance | Updated the main application in src/main.ts to integrate the new index (reindex) command and to enforce schema validation for create-pr commands. |