### PR TITLE
feat: add branch diff helper and update create-pr command

### DIFF
--- a/src/commands/create-pr-command.ts
+++ b/src/commands/create-pr-command.ts
@@ -5,6 +5,7 @@ import { generateSummary } from "@/github/summary";
 import {
   commit,
   fetchRemote,
+  getBranchDiffLikePullRequest,
   getCurrentBranch,
   getGitDiffFromRemoteBranch,
   getGitDiffToHead,
@@ -55,9 +56,16 @@ export async function executeCreatePRCommand(values: CreatePRValues) {
   // commit the changes
   await executeCommit(gitRoot, config, staged, dryRun);
 
+  // get the current branch
+  const currentBranch = await getCurrentBranch(gitRoot);
+
   // create a summary of the changes
   const defaultBranch = response.data.default_branch;
-  const diff = await getGitDiffFromRemoteBranch(gitRoot, defaultBranch);
+  const diff = await getBranchDiffLikePullRequest(
+    gitRoot,
+    defaultBranch,
+    currentBranch,
+  );
   if (!diff) {
     throw new CommandError("No changes to commit");
   }
@@ -83,9 +91,6 @@ export async function executeCreatePRCommand(values: CreatePRValues) {
     throw new CommandError("Failed to create a branch name");
   }
   console.log(`Created branch name: "${branchName}"`);
-
-  // get the current branch
-  const currentBranch = await getCurrentBranch(gitRoot);
 
   // push current branch to remote as a new branch
   if (dryRun) {

--- a/src/commands/create-pr-command.ts
+++ b/src/commands/create-pr-command.ts
@@ -3,12 +3,9 @@ import { readConfig } from "@/config";
 import { Octokit } from "@/github";
 import { generateSummary } from "@/github/summary";
 import {
-  commit,
   fetchRemote,
   getBranchDiffLikePullRequest,
   getCurrentBranch,
-  getGitDiffFromRemoteBranch,
-  getGitDiffToHead,
   getGitRepositoryRoot,
   getOriginOwnerAndRepo,
   pushToRemote,
@@ -60,10 +57,11 @@ export async function executeCreatePRCommand(values: CreatePRValues) {
   const currentBranch = await getCurrentBranch(gitRoot);
 
   // create a summary of the changes
+  const remote = "origin";
   const defaultBranch = response.data.default_branch;
   const diff = await getBranchDiffLikePullRequest(
     gitRoot,
-    defaultBranch,
+    `${remote}/${defaultBranch}`,
     currentBranch,
   );
   if (!diff) {

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,6 +1,10 @@
-export async function getGitDiffFromRemoteBranch(cwd: string, branch: string) {
+export async function getGitDiffFromRemoteBranch(
+  cwd: string,
+  remote: string,
+  branch: string,
+) {
   const result = Bun.spawn({
-    cmd: ["git", "diff", "--staged", `origin/${branch}`],
+    cmd: ["git", "diff", "--staged", `${remote}/${branch}`],
     cwd,
     stdout: "pipe",
     stderr: "pipe",

--- a/src/git.ts
+++ b/src/git.ts
@@ -23,7 +23,6 @@ export async function getBranchDiffLikePullRequest(
   baseBranch: string,
   targetBranch: string,
 ) {
-  console.log("getBranchDiffLikePullRequest", baseBranch, targetBranch);
   const mergeBase = await getMergeBase(cwd, baseBranch, targetBranch);
   const result = Bun.spawn({
     cmd: ["git", "diff", mergeBase],

--- a/src/git.ts
+++ b/src/git.ts
@@ -21,7 +21,7 @@ export async function getBranchDiffLikePullRequest(
 ) {
   const mergeBase = await getMergeBase(cwd, baseBranch, targetBranch);
   const result = Bun.spawn({
-    cmd: ["git", "diff", "--name-only", mergeBase, targetBranch],
+    cmd: ["git", "diff", mergeBase],
     cwd,
     stdout: "pipe",
     stderr: "pipe",

--- a/src/git.ts
+++ b/src/git.ts
@@ -19,6 +19,7 @@ export async function getBranchDiffLikePullRequest(
   baseBranch: string,
   targetBranch: string,
 ) {
+  console.log("getBranchDiffLikePullRequest", baseBranch, targetBranch);
   const mergeBase = await getMergeBase(cwd, baseBranch, targetBranch);
   const result = Bun.spawn({
     cmd: ["git", "diff", mergeBase],


### PR DESCRIPTION
| Category | Description |
|---|---|
| refactor | Removed the unused 'commit' import and reorganized the code in create-pr-command.ts for better clarity by moving the getCurrentBranch call earlier. |
| enhance | Replaced the call to getGitDiffFromRemoteBranch with getBranchDiffLikePullRequest to generate a diff more suitable for pull requests and introduced the explicit 'origin' remote variable. |
| enhance | Modified the getGitDiffFromRemoteBranch function in git.ts to accept a remote parameter instead of hardcoding 'origin', improving its flexibility. |
| feature | Added new functions getBranchDiffLikePullRequest and getMergeBase in git.ts to compute branch diffs based on the merge base with proper error handling, enabling more accurate diff generation for PRs. |

<!-- AICA GENERATED -->
## Summary

| Category | Description |
|---|---|
| enhance | Modified the create PR command to fetch the current branch earlier and use a new diff calculation strategy (getBranchDiffLikePullRequest) instead of the old approach, improving the diff generation logic for pull requests. |
| refactor | Refactored the getGitDiffFromRemoteBranch function in git.ts to accept a remote parameter instead of hardcoding 'origin', making it more flexible. |
| feature | Added new helper functions getBranchDiffLikePullRequest and getMergeBase in git.ts to calculate the merge base and generate a diff that resembles a pull request diff. |