### PR TITLE
feat: add push option to commit command and refactor CLI using yargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ Options:
 
 ### Other Commands
 
-- `aica version`: Show version information
-- `aica help [command]`: Show help information for a specific command or general help
+- `aica --version`: Show version information
+- `aica --help [command]`: Show help information for a specific command or general help
 
 ## GitHub Actions Settings
 

--- a/aica.example.toml
+++ b/aica.example.toml
@@ -1,5 +1,5 @@
 [llm]
-# provider = 'openai' | 'anthropic' | 'gemini'
+# provider = 'openai' | 'anthropic' | 'google'
 provider = 'openai'
 
 [llm.openai]
@@ -12,7 +12,7 @@ model = 'claude-3-5-sonnet-20241022'
 temperature = 0.5
 maxTokens = 4096
 
-[llm.gemini]
+[llm.google]
 model = 'gemini-2.0-flash'
 temperature = 0.5
 maxTokens = 4096

--- a/aica.example.toml
+++ b/aica.example.toml
@@ -1,5 +1,5 @@
 [llm]
-# provider = 'openai' | 'anthropic'
+# provider = 'openai' | 'anthropic' | 'gemini'
 provider = 'openai'
 
 [llm.openai]
@@ -9,6 +9,11 @@ maxCompletionTokens = 4096
 
 [llm.anthropic]
 model = 'claude-3-5-sonnet-20241022'
+temperature = 0.5
+maxTokens = 4096
+
+[llm.gemini]
+model = 'gemini-2.0-flash'
 temperature = 0.5
 maxTokens = 4096
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,11 +13,15 @@
         "@orama/plugin-parsedoc": "^2.1.0",
         "@orama/plugin-secure-proxy": "^2.1.1",
         "default-shell": "^2.2.0",
+        "globby": "^14.1.0",
         "os-name": "^6.0.0",
+        "yargs": "^17.7.2",
         "zod": "^3.24.2",
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "@types/glob": "^8.1.0",
+        "@types/yargs": "^17.0.33",
       },
       "peerDependencies": {
         "typescript": "^5.7.3",
@@ -51,6 +55,12 @@
 
     "@noble/hashes": ["@noble/hashes@1.7.1", "", {}, "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="],
 
+    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
+
+    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
+
+    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
     "@octokit/auth-token": ["@octokit/auth-token@5.1.2", "", {}, "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw=="],
 
     "@octokit/core": ["@octokit/core@6.1.4", "", { "dependencies": { "@octokit/auth-token": "^5.0.0", "@octokit/graphql": "^8.1.2", "@octokit/request": "^9.2.1", "@octokit/request-error": "^6.1.7", "@octokit/types": "^13.6.2", "before-after-hook": "^3.0.2", "universal-user-agent": "^7.0.0" } }, "sha512-lAS9k7d6I0MPN+gb9bKDt7X8SdxknYqAMh44S5L+lNqIN2NuV8nvv3g8rPp7MuRxcOpxpUIATWprO0C34a8Qmg=="],
@@ -83,13 +93,19 @@
 
     "@oramacloud/client": ["@oramacloud/client@1.3.20", "", { "dependencies": { "@orama/cuid2": "^2.2.3", "@orama/orama": "^2.0.16", "lodash": "^4.17.21", "openai": "^4.24.1", "react": "^18.2.0", "vue": "^3.4.25" } }, "sha512-UIN4l4KTcM6kpZQXakhQVQZinok6USFr7yEZM45fnS5ziW0jfVG8tjA2OhaLhQe0B9lHf5Wsio+PdwVUzgy0Xw=="],
 
+    "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@2.3.0", "", {}, "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg=="],
+
     "@types/bun": ["@types/bun@1.2.2", "", { "dependencies": { "bun-types": "1.2.2" } }, "sha512-tr74gdku+AEDN5ergNiBnplr7hpDp3V1h7fqI2GcR/rsUaM39jpSeKH0TFibRvU0KwniRx5POgaYnaXbk0hU+w=="],
 
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
+    "@types/glob": ["@types/glob@8.1.0", "", { "dependencies": { "@types/minimatch": "^5.1.2", "@types/node": "*" } }, "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w=="],
+
     "@types/hast": ["@types/hast@2.3.10", "", { "dependencies": { "@types/unist": "^2" } }, "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw=="],
 
     "@types/mdast": ["@types/mdast@3.0.15", "", { "dependencies": { "@types/unist": "^2" } }, "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ=="],
+
+    "@types/minimatch": ["@types/minimatch@5.1.2", "", {}, "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA=="],
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
@@ -102,6 +118,10 @@
     "@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "@types/ws": ["@types/ws@8.5.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw=="],
+
+    "@types/yargs": ["@types/yargs@17.0.33", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA=="],
+
+    "@types/yargs-parser": ["@types/yargs-parser@21.0.3", "", {}, "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="],
 
     "@vue/compiler-core": ["@vue/compiler-core@3.5.13", "", { "dependencies": { "@babel/parser": "^7.25.3", "@vue/shared": "3.5.13", "entities": "^4.5.0", "estree-walker": "^2.0.2", "source-map-js": "^1.2.0" } }, "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q=="],
 
@@ -125,6 +145,10 @@
 
     "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
 
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
@@ -143,6 +167,8 @@
 
     "brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
 
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
     "bun-types": ["bun-types@1.2.2", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-RCbMH5elr9gjgDGDhkTTugA21XtJAy/9jkKe/G3WR2q17VPGhcquf9Sir6uay9iW+7P/BV0CAHA1XlHXMAVKHg=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
@@ -154,6 +180,12 @@
     "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
     "clean-css": ["clean-css@5.3.3", "", { "dependencies": { "source-map": "~0.6.0" } }, "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg=="],
+
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
@@ -183,7 +215,11 @@
 
     "dpack": ["dpack@0.6.22", "", {}, "sha512-WGPNlW2OAE7Bj0eODMpAHUcEqxrlg01e9OFZDxQodminIgC194/cRHT7K04Z1j7AUEWTeeplYGrIv/xRdwU9Hg=="],
 
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
@@ -195,6 +231,12 @@
 
     "fast-content-type-parse": ["fast-content-type-parse@2.0.1", "", {}, "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q=="],
 
+    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fastq": ["fastq@1.19.0", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
     "form-data": ["form-data@4.0.1", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "mime-types": "^2.1.12" } }, "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw=="],
 
     "form-data-encoder": ["form-data-encoder@1.7.2", "", {}, "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="],
@@ -203,9 +245,15 @@
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
     "get-stream": ["get-stream@8.0.1", "", {}, "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA=="],
 
     "glob": ["glob@8.1.0", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^5.0.1", "once": "^1.3.0" } }, "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ=="],
+
+    "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "globby": ["globby@14.1.0", "", { "dependencies": { "@sindresorhus/merge-streams": "^2.1.0", "fast-glob": "^3.3.3", "ignore": "^7.0.3", "path-type": "^6.0.0", "slash": "^5.1.0", "unicorn-magic": "^0.3.0" } }, "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA=="],
 
     "hast-util-embedded": ["hast-util-embedded@2.0.1", "", { "dependencies": { "hast-util-is-element": "^2.0.0" } }, "sha512-QUdSOP1/o+/TxXtpPFXR2mUg2P+ySrmlX7QjwHZCXqMFyYk7YmcGSvqRW+4XgXAoHifdE1t2PwFaQK33TqVjSw=="],
 
@@ -255,6 +303,8 @@
 
     "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
 
+    "ignore": ["ignore@7.0.3", "", {}, "sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA=="],
+
     "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
@@ -266,6 +316,14 @@
     "is-buffer": ["is-buffer@2.0.5", "", {}, "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="],
 
     "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
@@ -294,6 +352,8 @@
     "mdast-util-to-string": ["mdast-util-to-string@3.2.0", "", { "dependencies": { "@types/mdast": "^3.0.0" } }, "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg=="],
 
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
+
+    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromark": ["micromark@3.2.0", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "micromark-core-commonmark": "^1.0.1", "micromark-factory-space": "^1.0.0", "micromark-util-character": "^1.0.0", "micromark-util-chunked": "^1.0.0", "micromark-util-combine-extensions": "^1.0.0", "micromark-util-decode-numeric-character-reference": "^1.0.0", "micromark-util-encode": "^1.0.0", "micromark-util-normalize-identifier": "^1.0.0", "micromark-util-resolve-all": "^1.0.0", "micromark-util-sanitize-uri": "^1.0.0", "micromark-util-subtokenize": "^1.0.0", "micromark-util-symbol": "^1.0.0", "micromark-util-types": "^1.0.1", "uvu": "^0.5.0" } }, "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA=="],
 
@@ -337,6 +397,8 @@
 
     "micromark-util-types": ["micromark-util-types@1.1.0", "", {}, "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg=="],
 
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
     "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
@@ -373,11 +435,17 @@
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
+    "path-type": ["path-type@6.0.0", "", {}, "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "postcss": ["postcss@8.5.2", "", { "dependencies": { "nanoid": "^3.3.8", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-MjOadfU3Ys9KYoX0AdkBlFEF1Vx37uCCeN4ZHnmwm9FfpbsGWMZeBLMmmpY+6Ocqod7mkdZ0DT31OlbsFrLlkA=="],
 
     "property-information": ["property-information@6.5.0", "", {}, "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig=="],
+
+    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
@@ -441,6 +509,12 @@
 
     "remark-rehype": ["remark-rehype@10.1.0", "", { "dependencies": { "@types/hast": "^2.0.0", "@types/mdast": "^3.0.0", "mdast-util-to-hast": "^12.1.0", "unified": "^10.0.0" } }, "sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw=="],
 
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "reusify": ["reusify@1.0.4", "", {}, "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="],
+
+    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
@@ -449,15 +523,23 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
+    "slash": ["slash@5.1.0", "", {}, "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="],
+
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "strip-final-newline": ["strip-final-newline@3.0.0", "", {}, "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
@@ -474,6 +556,8 @@
     "undici": ["undici@5.28.5", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA=="],
 
     "undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
+
+    "unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
 
     "unified": ["unified@10.1.2", "", { "dependencies": { "@types/unist": "^2.0.0", "bail": "^2.0.0", "extend": "^3.0.0", "is-buffer": "^2.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^5.0.0" } }, "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q=="],
 
@@ -515,7 +599,15 @@
 
     "windows-release": ["windows-release@6.0.1", "", { "dependencies": { "execa": "^8.0.1" } }, "sha512-MS3BzG8QK33dAyqwxfYJCJ03arkwKaddUOvvnnlFdXLudflsQF6I8yAxrLBeQk4yO8wjdH/+ax0YzxJEDrOftg=="],
 
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "devDependencies": {
     "@types/bun": "latest",
-    "@types/glob": "^8.1.0"
+    "@types/glob": "^8.1.0",
+    "@types/yargs": "^17.0.33"
   },
   "peerDependencies": {
     "typescript": "^5.7.3"
@@ -31,6 +32,7 @@
     "default-shell": "^2.2.0",
     "globby": "^14.1.0",
     "os-name": "^6.0.0",
+    "yargs": "^17.7.2",
     "zod": "^3.24.2"
   }
 }

--- a/src/commands/commit-message-command.ts
+++ b/src/commands/commit-message-command.ts
@@ -25,7 +25,7 @@ export async function createCommitMessage(
   cwd: string,
 ): Promise<string> {
   const git = new GitRepository(cwd);
-  const text = await git.getGitDiffToHead();
+  const text = await git.getGitDiffFromHead();
   if (!text) {
     throw new Error("No changes to commit");
   }

--- a/src/commands/summary-diff-command.ts
+++ b/src/commands/summary-diff-command.ts
@@ -21,7 +21,7 @@ export async function executeSummaryDiffCommand(
   const config = await readConfig();
   const targetDir = process.cwd();
   const git = new GitRepository(targetDir);
-  const diff = await git.getGitDiffToHead();
+  const diff = await git.getGitDiffFromHead();
   if (!diff) {
     throw new Error("No changes to summarize");
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import { deepAssign } from "./utility/deep-assign";
 import { GitRepository } from "./git";
 
-export type LLMProvider = "openai" | "anthropic" | "stub";
+export type LLMProvider = "openai" | "anthropic" | "stub" | "google";
 
 export type LLMConfigOpenAI = {
   model: string;
@@ -18,10 +18,18 @@ export type LLMConfigAnthropic = {
   maxTokens: number;
 };
 
+export type LLMConfigGemini = {
+  model: string;
+  apiKey: string;
+  temperature: number;
+  maxTokens: number;
+};
+
 export type LLMConfig = {
   provider: LLMProvider;
   openai: LLMConfigOpenAI;
   anthropic: LLMConfigAnthropic;
+  google: LLMConfigGemini;
   stub: {
     response: string;
   };
@@ -97,6 +105,12 @@ export const defaultConfig: Config = {
     anthropic: {
       model: Bun.env.ANTHROPIC_MODEL || "claude-3-5-sonnet-20241022",
       apiKey: Bun.env.ANTHROPIC_API_KEY || "",
+      temperature: 0.5,
+      maxTokens: 4096,
+    },
+    google: {
+      model: Bun.env.GOOGLE_MODEL || "gemini-2.0-flash",
+      apiKey: Bun.env.GOOGLE_API_KEY || Bun.env.GEMINI_API_KEY || "",
       temperature: 0.5,
       maxTokens: 4096,
     },

--- a/src/git.ts
+++ b/src/git.ts
@@ -85,7 +85,7 @@ export class GitRepository {
     return text;
   }
 
-  async getGitDiffToHead() {
+  async getGitDiffFromHead() {
     const result = Bun.spawn({
       cmd: ["git", "diff", "HEAD"],
       cwd: this.gitRootDir,
@@ -231,6 +231,17 @@ export class GitRepository {
     if (result.exitCode !== 0) {
       const text = (await new Response(result.stderr).text()).trim();
       throw new Error(`Failed to add files to stage: ${text}`);
+    }
+  }
+
+  async resetFiles(files: string[]) {
+    const result = Bun.spawn(["git", "reset", ...files], {
+      cwd: this.gitRootDir,
+    });
+    await result.exited;
+    if (result.exitCode !== 0) {
+      const text = (await new Response(result.stderr).text()).trim();
+      throw new Error(`Failed to reset files: ${text}`);
     }
   }
 

--- a/src/llm/factory.test.ts
+++ b/src/llm/factory.test.ts
@@ -1,0 +1,140 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { createLLM } from "./factory";
+import { LLMConfig, readConfig } from "@/config";
+
+describe("LLM Factory", () => {
+  let defaultConfig: LLMConfig;
+
+  beforeEach(async () => {
+    const config = await readConfig(null);
+    defaultConfig = config.llm;
+  });
+
+  describe("OpenAI Provider", () => {
+    test("should create OpenAI LLM instance", async () => {
+      if (!Bun.env.OPENAI_API_KEY) {
+        console.log(
+          "Skipping OpenAI LLM instance test: OPENAI_API_KEY is not set",
+        );
+        return;
+      }
+
+      const config: LLMConfig = {
+        ...defaultConfig,
+        provider: "openai",
+      };
+      const llm = createLLM(config);
+      expect(llm).toBeDefined();
+      expect(llm.generate).toBeInstanceOf(Function);
+    });
+
+    test("should generate text with OpenAI", async () => {
+      if (!Bun.env.OPENAI_API_KEY) {
+        console.log(
+          "Skipping OpenAI text generation test: OPENAI_API_KEY is not set",
+        );
+        return;
+      }
+
+      const config: LLMConfig = {
+        ...defaultConfig,
+        provider: "openai",
+        openai: {
+          ...defaultConfig.openai,
+          apiKey: Bun.env.OPENAI_API_KEY,
+        },
+      };
+      const llm = createLLM(config);
+      const response = await llm.generate(
+        "You are a helpful assistant.",
+        [{ role: "user", content: "Hello" }],
+        false,
+      );
+      expect(response).toBeDefined();
+      expect(typeof response).toBe("string");
+    });
+  });
+
+  describe("Anthropic Provider", () => {
+    test("should create Anthropic LLM instance", async () => {
+      if (!Bun.env.ANTHROPIC_API_KEY) {
+        console.log(
+          "Skipping Anthropic LLM instance test: ANTHROPIC_API_KEY is not set",
+        );
+        return;
+      }
+
+      const config: LLMConfig = {
+        ...defaultConfig,
+        provider: "anthropic",
+      };
+      const llm = createLLM(config);
+      expect(llm).toBeDefined();
+      expect(llm.generate).toBeInstanceOf(Function);
+    });
+
+    test("should generate text with Anthropic", async () => {
+      if (!Bun.env.ANTHROPIC_API_KEY) {
+        console.log(
+          "Skipping Anthropic text generation test: ANTHROPIC_API_KEY is not set",
+        );
+        return;
+      }
+
+      const config: LLMConfig = {
+        ...defaultConfig,
+        provider: "anthropic",
+        anthropic: {
+          ...defaultConfig.anthropic,
+          apiKey: Bun.env.ANTHROPIC_API_KEY,
+        },
+      };
+      const llm = createLLM(config);
+      const response = await llm.generate(
+        "You are a helpful assistant.",
+        [{ role: "user", content: "Hello" }],
+        false,
+      );
+      expect(response).toBeDefined();
+      expect(typeof response).toBe("string");
+    });
+  });
+
+  describe("Stub Provider", () => {
+    test("should create Stub LLM instance", async () => {
+      const config: LLMConfig = {
+        ...defaultConfig,
+        provider: "stub",
+      };
+      const llm = createLLM(config);
+      expect(llm).toBeDefined();
+      expect(llm.generate).toBeInstanceOf(Function);
+    });
+
+    test("should generate text with Stub", async () => {
+      const expectedResponse = "This is a stub response";
+      const config: LLMConfig = {
+        ...defaultConfig,
+        provider: "stub",
+        stub: {
+          response: expectedResponse,
+        },
+      };
+      const llm = createLLM(config);
+      const response = await llm.generate(
+        "You are a helpful assistant.",
+        [{ role: "user", content: "Hello" }],
+        false,
+      );
+      expect(response).toBe(expectedResponse);
+    });
+  });
+
+  test("should throw error for unknown provider", async () => {
+    const config = {
+      ...defaultConfig,
+      provider: "unknown" as any,
+    };
+    expect(() => createLLM(config)).toThrow("Unknown LLM provider: unknown");
+  });
+});

--- a/src/llm/factory.test.ts
+++ b/src/llm/factory.test.ts
@@ -130,6 +130,51 @@ describe("LLM Factory", () => {
     });
   });
 
+  describe("Google Provider", () => {
+    test("should create Google LLM instance", async () => {
+      if (!Bun.env.GOOGLE_API_KEY) {
+        console.log(
+          "Skipping Google LLM instance test: GOOGLE_API_KEY is not set",
+        );
+        return;
+      }
+
+      const config: LLMConfig = {
+        ...defaultConfig,
+        provider: "google",
+      };
+      const llm = createLLM(config);
+      expect(llm).toBeDefined();
+      expect(llm.generate).toBeInstanceOf(Function);
+    });
+
+    test("should generate text with Google", async () => {
+      if (!Bun.env.GOOGLE_API_KEY) {
+        console.log(
+          "Skipping Google text generation test: GOOGLE_API_KEY is not set",
+        );
+        return;
+      }
+
+      const config: LLMConfig = {
+        ...defaultConfig,
+        provider: "google",
+        google: {
+          ...defaultConfig.google,
+          apiKey: Bun.env.GOOGLE_API_KEY,
+        },
+      };
+      const llm = createLLM(config);
+      const response = await llm.generate(
+        "You are a helpful assistant.",
+        [{ role: "user", content: "Hello" }],
+        false,
+      );
+      expect(response).toBeDefined();
+      expect(typeof response).toBe("string");
+    });
+  });
+
   test("should throw error for unknown provider", async () => {
     const config = {
       ...defaultConfig,

--- a/src/llm/factory.ts
+++ b/src/llm/factory.ts
@@ -7,7 +7,7 @@ import { LLMStub } from "./stub";
 export function createLLM(settings: LLMConfig): LLM {
   const { provider, openai, anthropic } = settings;
   if (provider === "openai") {
-    return new LLMOpenAI(openai.apiKey, openai.model);
+    return new LLMOpenAI(openai);
   } else if (provider === "anthropic") {
     return new LLMAnthropic(anthropic);
   } else if (provider === "stub") {

--- a/src/llm/factory.ts
+++ b/src/llm/factory.ts
@@ -1,15 +1,18 @@
 import { LLMConfig } from "@/config";
 import { LLMAnthropic } from "./anthropic";
+import { LLMGoogle } from "./google";
 import { LLM } from "./llm";
 import { LLMOpenAI } from "./openai";
 import { LLMStub } from "./stub";
 
 export function createLLM(settings: LLMConfig): LLM {
-  const { provider, openai, anthropic } = settings;
+  const { provider, openai, anthropic, google } = settings;
   if (provider === "openai") {
     return new LLMOpenAI(openai);
   } else if (provider === "anthropic") {
     return new LLMAnthropic(anthropic);
+  } else if (provider === "google") {
+    return new LLMGoogle(google);
   } else if (provider === "stub") {
     return new LLMStub(settings.stub.response);
   } else {

--- a/src/llm/llm.test.ts
+++ b/src/llm/llm.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect } from "bun:test";
+import { extractJsonFromText } from "./llm";
+
+describe("extractJsonFrom", () => {
+  test("extracts JSON from plain markdown text", () => {
+    const markdown = `Here is some JSON: {"name": "test", "value": 123}`;
+    const expected = `{"name": "test", "value": 123}`;
+    expect(extractJsonFromText(markdown)).toBe(expected);
+  });
+
+  test("extracts JSON from code block", () => {
+    const markdown = '```json\n{"name": "test", "value": 123}\n```';
+    const expected = `{"name": "test", "value": 123}`;
+    expect(extractJsonFromText(markdown)).toBe(expected);
+  });
+
+  test("extracts JSON with explanation before it", () => {
+    const markdown =
+      'This is a configuration file:\n{"config": true, "debug": false}';
+    const expected = `{"config": true, "debug": false}`;
+    expect(extractJsonFromText(markdown)).toBe(expected);
+  });
+
+  test("returns null when no JSON is found", () => {
+    const markdown = "This is just a plain text without any JSON";
+    expect(extractJsonFromText(markdown)).toBeNull();
+  });
+
+  test("returns first JSON when multiple JSONs exist", () => {
+    const markdown = `
+            First JSON: {"id": 1, "name": "first"}
+            Second JSON: {"id": 2, "name": "second"}
+        `;
+    const expected = `{"id": 1, "name": "first"}`;
+    expect(extractJsonFromText(markdown)).toBe(expected);
+  });
+
+  test("handles nested JSON objects", () => {
+    const markdown =
+      'Complex JSON: {"user": {"name": "test", "settings": {"theme": "dark"}}}';
+    const expected = `{"user": {"name": "test", "settings": {"theme": "dark"}}}`;
+    expect(extractJsonFromText(markdown)).toBe(expected);
+  });
+});

--- a/src/llm/llm.ts
+++ b/src/llm/llm.ts
@@ -26,33 +26,33 @@ export class LLMError extends Error {
 }
 
 /**
- * テキストから最初のJSONを抽出する関数
- * @param text テキスト
- * @returns 見つかったJSONテキスト。見つからない場合はnull
+ * Function to extract the first JSON from text
+ * @param text input text
+ * @returns found JSON text, or null if not found
  */
 export function extractJsonFromText(text: string): string | null {
-  // コードブロック内のJSONを探す正規表現
+  // Regular expression to find JSON in code blocks
   const codeBlockRegex = /```(?:json)?\n({[\s\S]*?})\n```/;
-  // 通常のテキスト内のJSONを探す正規表現（ネストされたJSONに対応）
+  // Regular expression to find JSON in regular text (handles nested JSON)
   const jsonRegex = /{(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*}/;
 
-  // まずコードブロック内を探す
+  // First search in code blocks
   const codeBlockMatch = text.match(codeBlockRegex);
   if (codeBlockMatch) {
     try {
-      // 抽出したテキストがJSON形式か検証
+      // Validate extracted text is valid JSON
       JSON.parse(codeBlockMatch[1]);
       return codeBlockMatch[1];
     } catch {
-      // JSONとして無効な場合は次の検索に進む
+      // If invalid JSON, continue to next search
     }
   }
 
-  // 次に通常のテキスト内を探す
+  // Then search in regular text
   const matches = text.match(jsonRegex);
   if (matches) {
     try {
-      // 抽出したテキストがJSON形式か検証
+      // Validate extracted text is valid JSON
       JSON.parse(matches[0]);
       return matches[0];
     } catch {

--- a/src/llm/llm.ts
+++ b/src/llm/llm.ts
@@ -24,3 +24,41 @@ export class LLMError extends Error {
     this.name = "LLMError";
   }
 }
+
+/**
+ * テキストから最初のJSONを抽出する関数
+ * @param text テキスト
+ * @returns 見つかったJSONテキスト。見つからない場合はnull
+ */
+export function extractJsonFromText(text: string): string | null {
+  // コードブロック内のJSONを探す正規表現
+  const codeBlockRegex = /```(?:json)?\n({[\s\S]*?})\n```/;
+  // 通常のテキスト内のJSONを探す正規表現（ネストされたJSONに対応）
+  const jsonRegex = /{(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*}/;
+
+  // まずコードブロック内を探す
+  const codeBlockMatch = text.match(codeBlockRegex);
+  if (codeBlockMatch) {
+    try {
+      // 抽出したテキストがJSON形式か検証
+      JSON.parse(codeBlockMatch[1]);
+      return codeBlockMatch[1];
+    } catch {
+      // JSONとして無効な場合は次の検索に進む
+    }
+  }
+
+  // 次に通常のテキスト内を探す
+  const matches = text.match(jsonRegex);
+  if (matches) {
+    try {
+      // 抽出したテキストがJSON形式か検証
+      JSON.parse(matches[0]);
+      return matches[0];
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -100,6 +100,11 @@ async function main() {
             alias: "s",
             description: "Only include staged changes",
           })
+          .option("push", {
+            type: "boolean",
+            alias: "p",
+            description: "Push to remote repository",
+          })
           .option("dryRun", {
             type: "boolean",
             description: "Show result without execution",

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -61,7 +61,10 @@ export async function summarizeDiff(
     true,
   );
   try {
-    const replaced = result.replace(/^```json\n/, "").replace(/\n```$/, "");
+    const replaced = result
+      .trim()
+      .replace(/^```json\n/, "")
+      .replace(/\n```$/, "");
     const json = JSON.parse(replaced);
     return json.changes.map((change: any) => ({
       category: change.category,


### PR DESCRIPTION
| Category | Description |
|---|---|
| feature | Add '--push' option to commit command to push changes to remote after commit |
| enhance | Replace command line argument parsing from node:util to yargs for better CLI experience |
| enhance | Add JSON extraction utility function to handle LLM responses |
| refactor | Update command line help text format and command definitions |
| enhance | Add dry run support for git diff and push operations |
| refactor | Rename getGitDiffToHead to getGitDiffFromHead for better clarity |
| enhance | Add reset files functionality to GitRepository class |
| docs | Update README.md to reflect new command line option format |
| enhance | Add tests for JSON extraction functionality |

<!-- AICA GENERATED -->
## Summary

| Category | Description |
|---|---|
| docs | Update README.md to change CLI command syntax from 'aica version' and 'aica help' to 'aica --version' and 'aica --help'. |
| enhance | Update the package lock (bun.lock) and package.json files to add and update numerous dependencies (e.g. globby, yargs, and related type definitions) for improved functionality. |
| feature | Add a new 'push' option to the commit command, enabling commits to be optionally pushed to the remote repository. |
| refactor | Rename getGitDiffToHead to getGitDiffFromHead in multiple files and update associated method calls. Also add a new resetFiles function in the GitRepository class. |
| enhance | Improve the handling of Anthropic API responses by replacing manual JSON wrapping logic with the extractJsonFromText helper, adding better error handling. |
| refactor | Update LLM factory to instantiate LLMOpenAI by passing the full configuration object instead of discrete parameters. |
| enhance | Introduce a new test file for extractJsonFromText to validate proper JSON extraction from various text formats. |
| feature | Add a new extractJsonFromText utility function with inline documentation to extract JSON snippets from text, including code blocks and embedded text. |
| enhance | Migrate the CLI argument parsing in main.ts from the deprecated node:util parseArgs to a robust yargs-based parser with command definitions and strict validation. |
| refactor | Minor improvement in the summary function by trimming the result before processing to ensure correct JSON extraction. |