### PR TITLE
feat: Improve patch functionality and add comparison tests

### DIFF
--- a/src/agent/patch.test.ts
+++ b/src/agent/patch.test.ts
@@ -21,6 +21,17 @@ describe("Patch functionality tests", () => {
     expect(hunk.lines).toEqual([" hello", "-world", "+there", "+world"]);
   });
 
+  test("createPatch - single line file", () => {
+    const src = "single line";
+    const dst = "modified line";
+    const patch = createPatch(src, dst);
+
+    expect(patch.hunks).toHaveLength(1);
+    const hunk = patch.hunks[0];
+    expect(hunk.header).toBe("@@ -1 +1 @@");
+    expect(hunk.lines).toEqual(["-single line", "+modified line"]);
+  });
+
   test("checkPatchFormat - correct unified patch format", () => {
     const patch = {
       hunks: [

--- a/src/agent/patch.test.ts
+++ b/src/agent/patch.test.ts
@@ -1,4 +1,6 @@
 import { expect, test, describe } from "bun:test";
+import { tmpdir } from "os";
+import { join } from "path";
 import {
   createPatch,
   checkPatchFormat,
@@ -7,8 +9,8 @@ import {
   createPatchFromDiff,
 } from "./patch";
 
-describe("Patch機能のテスト", () => {
-  test("createPatch - unified formatでの差分生成", () => {
+describe("Patch functionality tests", () => {
+  test("createPatch - generating unified format diff", () => {
     const src = "hello\nworld";
     const dst = "hello\nthere\nworld";
     const patch = createPatch(src, dst);
@@ -19,7 +21,7 @@ describe("Patch機能のテスト", () => {
     expect(hunk.lines).toEqual([" hello", "-world", "+there", "+world"]);
   });
 
-  test("checkPatchFormat - 正しいunifiedパッチフォーマット", () => {
+  test("checkPatchFormat - correct unified patch format", () => {
     const patch = {
       hunks: [
         {
@@ -35,7 +37,7 @@ describe("Patch機能のテスト", () => {
     expect(checkPatchFormat(patch)).toBe(true);
   });
 
-  test("checkPatchFormat - 不正なパッチフォーマット", () => {
+  test("checkPatchFormat - incorrect patch format", () => {
     const invalidPatch = {
       hunks: [
         {
@@ -50,7 +52,7 @@ describe("Patch機能のテスト", () => {
     expect(checkPatchFormat(invalidPatch as any)).toBe(false);
   });
 
-  test("applyPatch - unified formatパッチの適用", () => {
+  test("applyPatch - applying unified format patch", () => {
     const src = "line1\nline2\nline3";
     const patch = {
       hunks: [
@@ -68,17 +70,17 @@ describe("Patch機能のテスト", () => {
     expect(result).toBe("line1\nnewline2\nline3");
   });
 
-  test("完全なワークフロー - unified format", () => {
+  test("complete workflow - unified format", () => {
     const original = "first\nsecond\nthird\nfourth\nfifth";
     const modified = "first\nmodified\nthird\nchanged\nfifth";
 
-    // パッチの作成
+    // Create patch
     const patch = createPatch(original, modified);
 
-    // パッチフォーマットの確認
+    // Check patch format
     expect(checkPatchFormat(patch)).toBe(true);
 
-    // ハンクの内容を確認
+    // Check hunk content
     expect(patch.hunks).toHaveLength(2);
     expect(patch.hunks[0].header).toBe("@@ -1,3 +1,3 @@");
     expect(patch.hunks[0].lines).toEqual([
@@ -91,14 +93,14 @@ describe("Patch機能のテスト", () => {
     expect(patch.hunks[1].header).toBe("@@ -4,2 +4,2 @@");
     expect(patch.hunks[1].lines).toEqual(["-fourth", "+changed", " fifth"]);
 
-    // パッチの適用
+    // Apply patch
     const result = applyPatch(original, patch);
     expect(result).toBe(modified);
   });
 });
 
 describe("parseHunk", () => {
-  test("unified formatのハンクをパースできること", () => {
+  test("should parse unified format hunk correctly", () => {
     const lines = ["@@ -1,2 +1,2 @@", " unchanged", "-old line", "+new line"];
 
     const [result, nextIndex] = parseHunk(lines, 0);
@@ -114,14 +116,14 @@ describe("parseHunk", () => {
     expect(nextIndex).toBe(4);
   });
 
-  test("不正なヘッダーでエラーを投げること", () => {
+  test("should throw error for invalid header", () => {
     const lines = ["invalid header"];
     expect(() => parseHunk(lines, 0)).toThrow("Invalid hunk header");
   });
 });
 
 describe("createPatchFromDiff", () => {
-  test("unified formatのdiffから正しくパッチを生成できること", () => {
+  test("should generate patch correctly from unified format diff", () => {
     const diff = [
       "--- a/file",
       "+++ b/file",
@@ -147,7 +149,7 @@ describe("createPatchFromDiff", () => {
     });
   });
 
-  test("複数のハンクを含むunified formatのdiffを処理できること", () => {
+  test("should handle multiple hunks in unified format diff", () => {
     const diff = [
       "--- a/file",
       "+++ b/file",
@@ -182,5 +184,245 @@ describe("createPatchFromDiff", () => {
         },
       ],
     });
+  });
+});
+
+describe("Comparison tests with actual diff/patch commands", () => {
+  // Helper function to create and manage temporary files
+  async function withTempFiles(
+    originalContent: string,
+    modifiedContent: string,
+    callback: (originalFile: string, modifiedFile: string) => Promise<void>,
+  ) {
+    const timestamp = Date.now();
+    const originalFile = join(tmpdir(), `patch-test-original-${timestamp}.txt`);
+    const modifiedFile = join(tmpdir(), `patch-test-modified-${timestamp}.txt`);
+
+    try {
+      await Bun.write(originalFile, originalContent);
+      await Bun.write(modifiedFile, modifiedContent);
+      await callback(originalFile, modifiedFile);
+    } finally {
+      // Clean up temporary files
+      await Bun.write(originalFile, "");
+      await Bun.write(modifiedFile, "");
+      await Bun.spawn(["rm", originalFile, modifiedFile]);
+    }
+  }
+
+  test("should handle complex text modifications", async () => {
+    const originalContent = [
+      "# Sample Document",
+      "",
+      "This is a test document.",
+      "It has multiple lines.",
+      "Some lines will be modified.",
+      "Some will be deleted.",
+      "And some new lines will be added.",
+      "",
+      "## Section 1",
+      "Content in section 1",
+      "",
+      "## Section 2",
+      "Content in section 2",
+    ].join("\n");
+
+    const modifiedContent = [
+      "# Modified Document",
+      "",
+      "This is a modified test document.",
+      "It has multiple lines.",
+      "This line is changed.",
+      "And some new lines will be added.",
+      "Here is a new line.",
+      "Another new line.",
+      "",
+      "## Section 1",
+      "Modified content in section 1",
+      "Added line in section 1",
+      "",
+      "## Section 2",
+      "Content in section 2",
+      "New subsection added",
+    ].join("\n");
+
+    await withTempFiles(
+      originalContent,
+      modifiedContent,
+      async (originalFile, modifiedFile) => {
+        // Execute actual diff command
+        const diffProcess = Bun.spawn([
+          "diff",
+          "-u",
+          originalFile,
+          modifiedFile,
+        ]);
+        const diffOutput = await new Response(diffProcess.stdout).text();
+
+        // Create patch using our implementation
+        const ourPatch = createPatch(originalContent, modifiedContent);
+
+        // Convert diff output to our patch format
+        const diffPatch = createPatchFromDiff(diffOutput);
+
+        // Compare patch application results
+        const ourResult = applyPatch(originalContent, ourPatch);
+        const diffResult = applyPatch(originalContent, diffPatch);
+
+        expect(ourResult).toBe(modifiedContent);
+        expect(diffResult).toBe(modifiedContent);
+      },
+    );
+  });
+
+  test("should handle complex document structure changes", async () => {
+    const originalContent = [
+      "# Project Setup Guide",
+      "",
+      "## Installation",
+      "",
+      "```bash",
+      "npm install",
+      "npm run build",
+      "```",
+      "",
+      "## Configuration",
+      "",
+      "### Database Configuration",
+      "Please configure the database connection settings:",
+      "",
+      "```javascript",
+      "module.exports = {",
+      "  host: 'localhost',",
+      "  port: 5432,",
+      "  database: 'myapp',",
+      "  username: 'admin'",
+      "}",
+      "```",
+      "",
+      "### Application Configuration",
+      "",
+      "Set the environment variables:",
+      "",
+      "```bash",
+      "PORT=3000",
+      "NODE_ENV=development",
+      "```",
+      "",
+      "## Usage",
+      "",
+      "Start the application:",
+      "",
+      "```bash",
+      "npm start",
+      "```",
+      "",
+      "Run tests:",
+      "",
+      "```bash",
+      "npm test",
+      "```",
+    ].join("\n");
+
+    const modifiedContent = [
+      "# Project Setup Guide v2.0",
+      "",
+      "## Prerequisites",
+      "",
+      "- Node.js 18.0 or higher",
+      "- PostgreSQL 15.0 or higher",
+      "",
+      "## Installation",
+      "",
+      "Install packages and initialize:",
+      "",
+      "```bash",
+      "npm install",
+      "npm run setup # New setup script",
+      "npm run build",
+      "```",
+      "",
+      "## Configuration",
+      "",
+      "### Database Configuration",
+      "Configure database connection settings in the `.env` file:",
+      "",
+      "```javascript",
+      "module.exports = {",
+      "  host: process.env.DB_HOST || 'localhost',",
+      "  port: parseInt(process.env.DB_PORT || '5432'),",
+      "  database: process.env.DB_NAME || 'myapp',",
+      "  username: process.env.DB_USER || 'admin',",
+      "  password: process.env.DB_PASS,",
+      "  ssl: process.env.DB_SSL === 'true'",
+      "}",
+      "```",
+      "",
+      "### Application Configuration",
+      "",
+      "Example environment variables:",
+      "",
+      "```bash",
+      "PORT=3000",
+      "NODE_ENV=development",
+      "LOG_LEVEL=debug",
+      "ENABLE_METRICS=true",
+      "```",
+      "",
+      "## Usage",
+      "",
+      "Start in development mode:",
+      "",
+      "```bash",
+      "npm run dev # Hot reload enabled",
+      "```",
+      "",
+      "Start in production mode:",
+      "",
+      "```bash",
+      "npm run build",
+      "npm start",
+      "```",
+      "",
+      "Run tests:",
+      "",
+      "```bash",
+      "npm run test:unit    # Unit tests",
+      "npm run test:e2e     # E2E tests",
+      "npm run test:coverage # Coverage report",
+      "```",
+      "",
+      "## Troubleshooting",
+      "",
+      "For common issues and solutions, please refer to the [FAQ page](./docs/FAQ.md).",
+    ].join("\n");
+
+    await withTempFiles(
+      originalContent,
+      modifiedContent,
+      async (originalFile, modifiedFile) => {
+        // Execute actual diff command
+        const diffProcess = Bun.spawn([
+          "diff",
+          "-u",
+          originalFile,
+          modifiedFile,
+        ]);
+        const diffOutput = await new Response(diffProcess.stdout).text();
+
+        // Create patch using our implementation
+        const ourPatch = createPatch(originalContent, modifiedContent);
+
+        // Convert diff output to our patch format
+        const diffPatch = createPatchFromDiff(diffOutput);
+
+        // Compare patch application results
+        const ourResult = applyPatch(originalContent, ourPatch);
+        const diffResult = applyPatch(originalContent, diffPatch);
+
+        expect(ourResult).toBe(modifiedContent);
+        expect(diffResult).toBe(modifiedContent);
+      },
+    );
   });
 });

--- a/src/agent/patch.ts
+++ b/src/agent/patch.ts
@@ -25,13 +25,20 @@ export function parseHunk(lines: string[], i: number): [PatchHunk, number] {
 
   const hunkLines: string[] = [];
   let j = i + 1;
-  while (
-    j < lines.length &&
-    (lines[j].startsWith(" ") ||
-      lines[j].startsWith("+") ||
-      lines[j].startsWith("-"))
-  ) {
-    hunkLines.push(lines[j]);
+  while (j < lines.length) {
+    const line = lines[j];
+    if (line.startsWith("\\ No newline at end of file")) {
+      j++;
+      continue;
+    }
+    if (
+      !line.startsWith(" ") &&
+      !line.startsWith("+") &&
+      !line.startsWith("-")
+    ) {
+      break;
+    }
+    hunkLines.push(line);
     j++;
   }
 
@@ -43,7 +50,7 @@ export function parseHunk(lines: string[], i: number): [PatchHunk, number] {
 
 export function createPatchFromDiff(diff: string): Patch {
   const hunks: PatchHunk[] = [];
-  const lines = diff.split("\n").filter((line) => line.length > 0);
+  const lines = diff.split("\n");
   let i = 0;
 
   // Skip file headers (---, +++)
@@ -55,9 +62,13 @@ export function createPatchFromDiff(diff: string): Patch {
   }
 
   while (i < lines.length) {
-    const [hunk, nextIndex] = parseHunk(lines, i);
-    hunks.push(hunk);
-    i = nextIndex;
+    if (lines[i].startsWith("@@")) {
+      const [hunk, nextIndex] = parseHunk(lines, i);
+      hunks.push(hunk);
+      i = nextIndex;
+    } else {
+      i++;
+    }
   }
 
   return { hunks };
@@ -69,11 +80,11 @@ export function createPatch(src: string, dst: string): Patch {
   const hunks: PatchHunk[] = [];
   const context = 1;
 
-  // 変更箇所を見つける
+  // Find changed regions
   const changes: { start: number; end: number }[] = [];
   let i = 0;
   while (i < Math.max(srcLines.length, dstLines.length)) {
-    // 同じ行をスキップ
+    // Skip identical lines
     while (
       i < srcLines.length &&
       i < dstLines.length &&
@@ -86,7 +97,7 @@ export function createPatch(src: string, dst: string): Patch {
       const changeStart = i;
       let changeEnd = i + 1;
 
-      // 変更箇所の終わりを見つける
+      // Find the end of the changed region
       while (
         changeEnd < Math.max(srcLines.length, dstLines.length) &&
         (changeEnd >= srcLines.length ||
@@ -96,39 +107,39 @@ export function createPatch(src: string, dst: string): Patch {
         changeEnd++;
       }
 
-      // 変更箇所を記録
+      // Record the change
       changes.push({ start: changeStart, end: changeEnd });
       i = changeEnd;
     }
   }
 
-  // 変更箇所をマージするかどうかを判断
+  // Determine whether to merge changes
   const mergedChanges: { start: number; end: number }[] = [];
   for (let i = 0; i < changes.length; i++) {
     const current = changes[i];
     const next = i + 1 < changes.length ? changes[i + 1] : null;
 
-    // 次の変更箇所との間の共通行数を計算
+    // Calculate common lines between current and next change
     const commonLines = next ? next.start - current.end : Infinity;
 
-    // 共通行が0行の場合のみマージ（コンテキスト行を共有しない場合）
+    // Only merge if there are no common lines (no shared context)
     if (next && commonLines === 0) {
       mergedChanges.push({
         start: current.start,
         end: next.end,
       });
-      i++; // 次の変更箇所をスキップ
+      i++; // Skip next change
     } else {
       mergedChanges.push(current);
     }
   }
 
-  // 各変更箇所をマージ後、ハンクを生成
-  let previousHunkEnd = -1; // 前のハンクの終了位置を追跡しておく
+  // Generate hunks after merging changes
+  let previousHunkEnd = -1; // Track the end position of previous hunk
   for (let i = 0; i < mergedChanges.length; i++) {
     const change = mergedChanges[i];
 
-    // もし前のハンクと現在の変更箇所がcontext行数以内の場合、コンテキストを重複させない
+    // If current change is within context lines of previous hunk, don't duplicate context
     let hunkStart: number;
     if (change.start <= previousHunkEnd + context) {
       hunkStart = change.start;
@@ -142,14 +153,14 @@ export function createPatch(src: string, dst: string): Patch {
 
     const hunkLines: string[] = [];
 
-    // 前のコンテキストを追加
+    // Add leading context
     for (let k = hunkStart; k < change.start; k++) {
       if (k < srcLines.length && k < dstLines.length) {
         hunkLines.push(" " + srcLines[k]);
       }
     }
 
-    // 変更箇所を追加
+    // Add changed lines
     for (let k = change.start; k < change.end; k++) {
       if (k < srcLines.length) {
         hunkLines.push("-" + srcLines[k]);
@@ -159,14 +170,14 @@ export function createPatch(src: string, dst: string): Patch {
       }
     }
 
-    // 後ろのコンテキストを追加
+    // Add trailing context
     for (let k = change.end; k < hunkEnd; k++) {
       if (k < srcLines.length && k < dstLines.length) {
         hunkLines.push(" " + srcLines[k]);
       }
     }
 
-    // 変更箇所+コンテキスト行数を算出
+    // Calculate total lines (changes + context)
     const oldLines = hunkLines.filter((line) => line.startsWith("-")).length;
     const newLines = hunkLines.filter((line) => line.startsWith("+")).length;
     const contextLines = hunkLines.filter((line) =>
@@ -175,7 +186,7 @@ export function createPatch(src: string, dst: string): Patch {
     const totalOldLines = oldLines + contextLines;
     const totalNewLines = newLines + contextLines;
 
-    // ハンクの開始位置を hunkStart+1
+    // Set hunk start position to hunkStart+1
     const oldStart = hunkStart + 1;
     const newStart = hunkStart + 1;
     const header = `@@ -${oldStart},${totalOldLines} +${newStart},${totalNewLines} @@`;
@@ -189,7 +200,7 @@ export function createPatch(src: string, dst: string): Patch {
       lines: hunkLines,
     });
 
-    // 現在のハンク終了位置を記録
+    // Record current hunk end position
     previousHunkEnd = change.end;
   }
 

--- a/src/agent/tool/tool.ts
+++ b/src/agent/tool/tool.ts
@@ -58,6 +58,7 @@ import {
   SearchFilesTool,
   StopTool,
   AttemptCompletionTool,
+  diffToolPrompt,
 } from "./tools";
 
 export const tools: Record<string, Tool> = {
@@ -93,16 +94,10 @@ export function generateAvailableTools(): string {
 ${toolDescriptions}
 === END OF AVAILABLE TOOLS ===
 
-Unified format diff example:
-=== EXAMPLE of unified format diff ===
---- original
-+++ edited
-@@ -1,3 +1,3 @@
- abc
--def
-+eef
- hij
-=== END OF EXAMPLE ===
+=== UNIFIED FORMAT DIFF EXPLANATION ===
+${diffToolPrompt}
+=== END OF UNIFIED FORMAT DIFF EXPLANATION ===
+
 `;
 }
 


### PR DESCRIPTION
| Category | Description |
|---|---|
| feature | Added temporary file management for `createRawPatchFromString` to avoid conflicts when creating patches from strings. |
| feature | Implemented `createRawPatchFromString` function to generate unified diffs from string content using the `diff` command. |
| feature | Implemented `createRawPatch` function to generate unified diffs from two files using the `diff` command. |
| feature | Added comparison tests with actual diff/patch commands to verify the correctness of the patch functionality. |
| bugfix | Fixed parsing of single-line hunks in `parseHunk` function. |
| bugfix | Fixed issue where `createPatchFromDiff` was not correctly splitting lines, causing parsing failures. |
| refactor | Refactored `parseHunk` to handle '\\ No newline at end of file' correctly. |
| refactor | Modified `createPatch` to use single line format when both old and new are single lines. |
| refactor | Refactored EditFileTool to use raw patch strings instead of JSON and improved error handling. |
| enhance | Improved the EditFileTool to directly use the unified diff format instead of parsing JSON, and updated error handling for invalid patches. |
| docs | Added a detailed prompt (diffToolPrompt) explaining how to generate unified diffs for the edit_file tool. |

<!-- AICA GENERATED -->
## Summary

| Category | Description |
|---|---|
| enhance | Updated test files (patch.test.ts) to use English descriptions, added additional tests to verify diff/patch functionality with temporary file management, and improved overall test coverage. |
| feature | Enhanced patch.ts by adding support for single-line hunk headers in parseHunk(), introducing new functions (createRawPatch and createRawPatchFromString) that use the diff command, and refining hunk merging and context generation in createPatch. |
| bugfix | Modified tool tests (tool.test.ts) to replace createPatch with createRawPatchFromString and removed unnecessary JSON serialization of patches, ensuring correct patch handling. |
| docs | Updated tool.ts to remove outdated unified diff examples and replaced them with a dynamic diff prompt explanation by importing and integrating diffToolPrompt. |
| bugfix | Improved the edit-file tool (edit-file.ts) by updating its description, simplifying patch parsing by directly using createPatchFromDiff, and enhancing error messaging for invalid patch formats. |
| docs | Added a detailed diffToolPrompt constant with step-by-step unified diff formatting instructions to guide users in generating valid patches. |