### PR TITLE
feat: add retry mechanism with rate limit handling for LLM API calls

### DIFF
--- a/src/llm/llm.ts
+++ b/src/llm/llm.ts
@@ -1,9 +1,43 @@
+export interface LLMOptions {
+  maxRetries?: number;
+  retryDelay?: number;
+}
+
 export interface LLM {
   generate(
     systemPrompt: string,
     prompts: Message[],
     jsonMode: boolean,
+    options?: LLMOptions,
   ): Promise<string>;
+}
+
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: LLMOptions = {},
+): Promise<T> {
+  const maxRetries = options.maxRetries ?? 3;
+  const retryDelay = options.retryDelay ?? 1000;
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (attempt === maxRetries) {
+        throw error;
+      }
+      let backoffDelay = retryDelay * Math.pow(2, attempt - 1);
+      console.warn(
+        `LLM attempt ${attempt} failed, retrying in ${backoffDelay}ms...`,
+      );
+      if (error instanceof LLMRateLimitError) {
+        backoffDelay = 20 * 1000;
+      }
+      await new Promise((resolve) => setTimeout(resolve, backoffDelay));
+    }
+  }
+  // This should never be reached due to throw in the loop
+  throw new Error("Unexpected end of retry loop");
 }
 
 export type Message = UserMessage | AssistantMessage;
@@ -22,6 +56,22 @@ export class LLMError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "LLMError";
+  }
+}
+
+export class LLMTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LLMTimeoutError";
+  }
+}
+
+export class LLMRateLimitError extends Error {
+  retryAfter: number | undefined;
+  constructor(message: string, retryAfter?: number) {
+    super(message);
+    this.name = "LLMRateLimitError";
+    this.retryAfter = retryAfter;
   }
 }
 

--- a/src/llm/logger.ts
+++ b/src/llm/logger.ts
@@ -10,7 +10,12 @@ export function createLLMLogger(logFile: string | undefined): LLMLogger {
   const logger = winston.createLogger({
     level: "info",
     format: winston.format.simple(),
-    transports: [],
+    transports: [
+      new winston.transports.Console({
+        format: winston.format.simple(),
+        level: "error",
+      }),
+    ],
   });
 
   if (logFile) {


### PR DESCRIPTION
| Category | Description |
|---|---|
| feature | Add retry mechanism with exponential backoff for LLM API calls |
| feature | Add rate limit error handling for Anthropic, Google, and OpenAI APIs |
| enhance | Add LLMOptions interface to configure retry behavior (maxRetries and retryDelay) |
| feature | Add new error classes: LLMTimeoutError and LLMRateLimitError for better error handling |
| enhance | Add console transport to winston logger for error level messages |
| refactor | Extract common retry logic into withRetry utility function |
| enhance | Improve error messages and error handling across all LLM providers |
| enhance | Add special handling for rate limit errors with 20 seconds backoff |

<!-- AICA GENERATED -->
## Summary

| Category | Description |
|---|---|
| enhance | Added a new retry mechanism with the 'withRetry' function to automatically retry failed API calls with exponential backoff, including special handling for rate limit errors. |
| feature | Introduced the 'LLMOptions' interface to allow configuring retry parameters (e.g., maxRetries, retryDelay) and passed these options into API methods in the Anthropic, Google, and OpenAI classes. |
| enhance | Improved error handling across multiple LLM implementations by checking for HTTP 429 responses and throwing a specific 'LLMRateLimitError' (with optional retry delay information). |
| refactor | Refactored import statements and method signatures to include new dependencies (withRetry, LLMOptions, LLMRateLimitError) and to streamline common behaviors across modules. |
| enhance | Enhanced the logger configuration by adding a console transport to log error level messages in the logger module. |
| enhance | Consolidated error handling by removing redundant try/catch blocks and integrating the new retry strategy in the Google and OpenAI LLM implementations. |