### PR TITLE
feat: change default LLM provider to Anthropic and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ aica agent -f instruction.txt
 
 This command executes a task using an AI agent. The agent automatically determines and executes the necessary actions based on the given prompt.
 
+Recommend to use anthropic claude 3.5 sonnet for agent.
+
 NOTE: This command has potential to break your file system. Please be careful.
 
 ### Reindex

--- a/aica.example.toml
+++ b/aica.example.toml
@@ -1,6 +1,6 @@
 [llm]
 # provider = 'openai' | 'anthropic' | 'google'
-provider = 'openai'
+provider = 'anthropic'
 
 [llm.openai]
 model = 'o3-mini'

--- a/src/config.ts
+++ b/src/config.ts
@@ -104,7 +104,7 @@ export type Config = {
 export const defaultConfig: Config = {
   workingDirectory: ".",
   llm: {
-    provider: (Bun.env.AICA_LLM_PROVIDER as LLMProvider) || "openai",
+    provider: (Bun.env.AICA_LLM_PROVIDER as LLMProvider) || "anthropic",
     openai: {
       model: Bun.env.OPENAI_MODEL || "o3-mini",
       apiKey: Bun.env.OPENAI_API_KEY || "",


### PR DESCRIPTION
| Category | Description |
|---|---|
| enhance | Change default LLM provider from OpenAI to Anthropic in configuration files |
| docs | Add recommendation to use Claude 3.5 Sonnet for agent in README.md |
| enhance | Update default LLM provider in config.ts from 'openai' to 'anthropic' |
| enhance | Update example configuration in aica.example.toml to use Anthropic as default provider |

<!-- AICA GENERATED -->
## Summary

| Category | Description |
|---|---|
| docs | Updated README.md by adding a recommendation to use anthropic claude 3.5 sonnet with the agent. |
| enhance | Changed default provider in aica.example.toml from 'openai' to 'anthropic'. |
| enhance | Modified the default configuration in src/config.ts to default to 'anthropic' when no environment variable is provided. |