### PR TITLE
feat: add pull request config and set anthropic as default provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ aica agent -f instruction.txt
 
 This command executes a task using an AI agent. The agent automatically determines and executes the necessary actions based on the given prompt.
 
+Recommend to use anthropic claude 3.5 sonnet for agent.
+
 NOTE: This command has potential to break your file system. Please be careful.
 
 ### Reindex

--- a/aica.example.toml
+++ b/aica.example.toml
@@ -1,6 +1,6 @@
 [llm]
 # provider = 'openai' | 'anthropic' | 'google'
-provider = 'openai'
+provider = 'anthropic'
 
 [llm.openai]
 model = 'o3-mini'

--- a/aica.example.toml
+++ b/aica.example.toml
@@ -132,3 +132,9 @@ EXAMPLES:
 - docs: update the documentation
 - style: update the style
 """
+
+[pullRequest]
+# generate a summary of the changes as a pull request description.
+withSummary = true
+# if true, create a pull request as a draft.
+draft = false

--- a/src/commands/create-pr-command.ts
+++ b/src/commands/create-pr-command.ts
@@ -13,10 +13,10 @@ export const createPrCommandSchema = z.object({
   dryRun: z.boolean().default(false),
   baseBranch: z.string().default("main"),
   branchName: z.string().optional(),
-  withSummary: z.boolean().default(true),
+  withSummary: z.boolean().optional(),
   title: z.string().optional(),
   body: z.string().optional(),
-  draft: z.boolean().default(false),
+  draft: z.boolean().optional(),
 });
 
 export type CreatePrCommandValues = z.infer<typeof createPrCommandSchema>;
@@ -32,9 +32,12 @@ export async function executeCreatePrCommand(
     branchName,
     title,
     body,
-    draft,
-    withSummary,
+    draft: argDraft,
+    withSummary: argWithSummary,
   } = values;
+
+  const draft = argDraft ?? config.pullRequest.draft;
+  const withSummary = argWithSummary ?? config.pullRequest.withSummary;
 
   const cwd = process.cwd();
   const gitRoot = await GitRepository.getRepositoryRoot(cwd);
@@ -98,6 +101,7 @@ export async function executeCreatePrCommand(
       prBody,
       baseBranch,
       targetBranchName,
+      draft,
     );
 
     if (draft) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -104,7 +104,7 @@ export type Config = {
 export const defaultConfig: Config = {
   workingDirectory: ".",
   llm: {
-    provider: (Bun.env.AICA_LLM_PROVIDER as LLMProvider) || "openai",
+    provider: (Bun.env.AICA_LLM_PROVIDER as LLMProvider) || "anthropic",
     openai: {
       model: Bun.env.OPENAI_MODEL || "o3-mini",
       apiKey: Bun.env.OPENAI_API_KEY || "",

--- a/src/config.ts
+++ b/src/config.ts
@@ -95,6 +95,10 @@ export type Config = {
       user: string;
     };
   };
+  pullRequest: {
+    withSummary: boolean;
+    draft: boolean;
+  };
   source: {
     includePatterns: string[];
     excludePatterns: string[];
@@ -183,6 +187,10 @@ export const defaultConfig: Config = {
         - docs: update readme
       `.replaceAll(/\n +/g, "\n"),
     },
+  },
+  pullRequest: {
+    withSummary: true,
+    draft: false,
   },
   source: {
     includePatterns: [


### PR DESCRIPTION
| Category | Description |
|---|---|
| feature | Add new configuration options for pull request settings (withSummary and draft) in config.toml |
| enhance | Change default LLM provider from OpenAI to Anthropic in both config and example files |
| enhance | Make withSummary and draft parameters optional in PR command schema, falling back to config values |
| enhance | Implement draft PR support in create-pr-command execution |
| docs | Add recommendation to use Claude 3.5 Sonnet for agent in README.md |
| refactor | Improve PR command parameter handling by using config fallbacks |

<!-- AICA GENERATED -->
## Summary

| Category | Description |
|---|---|
| docs | Updated README.md to add a recommendation for using anthropic claude 3.5 sonnet for the agent. |
| enhance | Changed the default llm provider from 'openai' to 'anthropic' in both aica.example.toml and the default configuration in config.ts. |
| feature | Added a new pullRequest section in aica.example.toml with 'withSummary' and 'draft' options to control pull request creation behavior. |
| enhance | Modified the create-pr-command schema in create-pr-command.ts to make 'withSummary' and 'draft' optional, using values from the config when not provided. |
| enhance | Extended the configuration in config.ts to include pullRequest settings for summary generation and draft creation. |