### PR TITLE
feat: add default LLM provider detection and API key validation

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -110,10 +110,26 @@ export type Config = {
   };
 };
 
+const getDefaultLLMProvider = (): LLMProvider => {
+  if (Bun.env.AICA_LLM_PROVIDER) {
+    return Bun.env.AICA_LLM_PROVIDER as LLMProvider;
+  }
+  if (Bun.env.ANTHROPIC_API_KEY) {
+    return "anthropic";
+  }
+  if (Bun.env.OPENAI_API_KEY) {
+    return "openai";
+  }
+  if (Bun.env.GOOGLE_API_KEY || Bun.env.GEMINI_API_KEY) {
+    return "google";
+  }
+  return "anthropic";
+};
+
 export const defaultConfig: Config = {
   workingDirectory: ".",
   llm: {
-    provider: (Bun.env.AICA_LLM_PROVIDER as LLMProvider) || "anthropic",
+    provider: getDefaultLLMProvider(),
     openai: {
       model: Bun.env.OPENAI_MODEL || "o3-mini",
       apiKey: Bun.env.OPENAI_API_KEY || "",

--- a/src/llm/anthropic.ts
+++ b/src/llm/anthropic.ts
@@ -38,6 +38,9 @@ export class LLMAnthropic implements LLM {
   private logger: LLMLogger;
 
   constructor(config: LLMConfigAnthropic) {
+    if (!config.apiKey) {
+      throw new Error("Anthropic API key is not set");
+    }
     this.apiKey = config.apiKey;
     this.model = config.model;
     this.temperature = config.temperature;

--- a/src/llm/google.ts
+++ b/src/llm/google.ts
@@ -14,6 +14,9 @@ export class LLMGoogle implements LLM {
   private logger: LLMLogger;
 
   constructor(config: LLMConfigGemini) {
+    if (!config.apiKey) {
+      throw new Error("Google API key is not set");
+    }
     this.config = config;
     this.logger = createLLMLogger(config.logFile);
   }

--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -25,6 +25,9 @@ export class LLMOpenAI implements LLM {
   private logger: LLMLogger;
 
   constructor(config: LLMConfigOpenAI) {
+    if (!config.apiKey) {
+      throw new Error("OpenAI API key is not set");
+    }
     this.apiKey = config.apiKey;
     this.model = config.model;
     this.temperature = config.temperature;


### PR DESCRIPTION
<!-- AICA GENERATED -->
## Summary

| Category | Description |
|---|---|
| feature | Introduce a helper function getDefaultLLMProvider() to determine the default LLM provider based on available environment variables (AICA_LLM_PROVIDER, ANTHROPIC_API_KEY, OPENAI_API_KEY, GOOGLE_API_KEY/GEMINI_API_KEY) with a fallback to 'anthropic'. |
| refactor | Refactor the default configuration to use getDefaultLLMProvider(), thereby centralizing and simplifying the provider selection logic. |
| bugfix | Add API key validation in the constructors of Anthropic, Google, and OpenAI LLM classes by throwing an error if the respective API key is not set, preventing potential misconfigurations. |