### PR TITLE
docs: add GitHub token setup instructions and use gh auth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,14 @@ bun run build
 cp ./dist/aica path-to-your-bin-directory
 ```
 
-Setup environment variables:
+Setup GitHub Token:
+
+```bash
+# if GITHUB_TOKEN is not set, aica try to get token from `gh auth token`.
+export GITHUB_TOKEN=your_github_token
+```
+
+Setup LLM:
 
 ```bash
 # You can set the following items in your environment variables or aica.toml file.

--- a/src/commands/create-pr-command.ts
+++ b/src/commands/create-pr-command.ts
@@ -1,6 +1,6 @@
 import { readConfig, type Config } from "@/config";
 import { GitRepository } from "@/git";
-import { Octokit } from "@/github";
+import { getGitHubToken, Octokit } from "@/github";
 import { z } from "zod";
 import { executeCommit } from "./commit-command";
 import { createCommitMessageFromDiff } from "./commit-message-command";
@@ -89,8 +89,9 @@ export async function executeCreatePrCommand(
     }
     await git.pushToRemote(remoteName, targetBranchName);
 
+    const token = await getGitHubToken();
     const octokit = new Octokit({
-      auth: process.env.GITHUB_TOKEN,
+      auth: token,
     });
 
     const pr = await PullRequest.create(


### PR DESCRIPTION
<!-- AICA GENERATED -->
## Summary

| Category | Description |
|---|---|
| docs | Updated README.md to explicitly instruct users to set up a GitHub token, including code snippet details for token export. |
| enhance | Modified create-pr command to retrieve the GitHub token using getGitHubToken and pass it to Octokit, replacing the direct use of process.env.GITHUB_TOKEN. |