### PR TITLE
feat: add language configuration support for AI output

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,20 @@ aica.toml must be placed in one of the following directories.
 - ${HOME}/.config/aica/aica.toml
 - ${GITHUB_WORKSPACE}/aica.toml
 
+### Language
+
+You can specify the language for AI output. The language can be specified either through AICA_LANGUAGE or in the language section of aica.toml. By default, the language is automatically detected from the LANG environment variable.
+
+```bash
+export AICA_LANGUAGE=Japanese
+```
+
+Priority:
+
+1. `AICA_LANGUAGE`
+2. `language.language` in aica.toml
+3. Automatic detection from `LANG`
+
 ## Usage
 
 ### Review

--- a/aica.example.toml
+++ b/aica.example.toml
@@ -21,10 +21,10 @@ maxTokens = 4096
 # logFile = '/path/to/google.log'  # Optional: Path to log Google API calls
 
 [language]
-# auto detect language from environment variable.
-autoDetect = true
-# autoDetect is true, so this is ignored.
-language = 'English'
+# if set language to 'auto', aica try to detect language from environment variable.
+# language = 'English'
+# language = 'Japanese'
+language = 'auto'
 
 [source]
 includePatterns = [

--- a/src/config.ts
+++ b/src/config.ts
@@ -64,7 +64,6 @@ export type Knowledge = {
 };
 
 export type LanguageConfig = {
-  autoDetect: boolean;
   language: string;
 };
 
@@ -156,8 +155,7 @@ export const defaultConfig: Config = {
     },
   },
   language: {
-    autoDetect: true,
-    language: "",
+    language: "auto",
   },
   embedding: {
     provider: "openai",

--- a/src/utility/language.ts
+++ b/src/utility/language.ts
@@ -12,14 +12,16 @@ export function getLanguagePromptForJson(
 }
 
 export function getLanguageFromConfig(config: Config) {
-  let result = config.language.language || "English";
-  if (config.language.autoDetect) {
-    result = getLanguageFromEnv();
+  const configLang = config.language.language.toLowerCase().trim();
+  if (Bun.env.AICA_LANGUAGE) {
+    return Bun.env.AICA_LANGUAGE;
+  } else if (configLang && configLang !== "auto") {
+    return configLang;
   }
-  return result;
+  return getLanguageFromLang();
 }
 
-export function getLanguageFromEnv() {
+export function getLanguageFromLang() {
   const lang = Bun.env.LANG?.split(".")[0]?.split("_")[0] || "en";
   const fullLangNames = {
     en: "English",


### PR DESCRIPTION
<!-- AICA GENERATED -->
## Summary

| Category | Description |
|---|---|
| docs | Added a new 'Language' section in README.md explaining how to specify the output language using AICA_LANGUAGE and aica.toml configuration, including priority rules. |
| enhance | Updated the aica.example.toml file by replacing the autoDetect boolean and fixed language configuration comments, setting the default language value to 'auto'. |
| refactor | Removed the autoDetect property from the LanguageConfig type in src/config.ts and updated defaultConfig accordingly. |
| enhance | Refined language detection logic in src/utility/language.ts to prioritize the AICA_LANGUAGE environment variable, simplify the conditionals, and fall back to automatic detection based on the LANG environment variable. |