### PR TITLE
feat: add support for .cursorrules and .clinerules auto-loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,14 @@ Options:
 - `aica --version`: Show version information
 - `aica --help [command]`: Show help information for a specific command or general help
 
+## Add Context
+
+.cursorrules and .clinerules are automatically added to the context.
+If you want to customize the context, configure the [rules] section in aica.toml.
+
+Additionally, .cursor/rules/\*.mdc files are supported by default.
+This function can be disabled through the settings.
+
 ## GitHub Actions
 
 ### Setup

--- a/src/config.ts
+++ b/src/config.ts
@@ -162,7 +162,7 @@ export const defaultConfig: Config = {
   },
   rules: {
     findCursorRules: true,
-    files: [],
+    files: [".cursorrules", ".clinerules"],
   },
   language: {
     language: "auto",

--- a/src/llmcontext/rules-finder.ts
+++ b/src/llmcontext/rules-finder.ts
@@ -117,9 +117,12 @@ export class RulesFinder {
     for (const filePath of this.config.files) {
       const fullPath = path.resolve(this.baseDir, filePath);
       try {
-        const content = await Bun.file(fullPath).text();
-        if (content) {
-          rules.push(content);
+        const file = Bun.file(fullPath);
+        if (await file.exists()) {
+          const content = await file.text();
+          if (content) {
+            rules.push(content);
+          }
         }
       } catch (error) {
         console.error(`Error reading fixed rule file ${fullPath}:`, error);


### PR DESCRIPTION
<!-- AICA GENERATED -->
## Summary

| Category | Description |
|---|---|
| docs | Updated README.md with a new 'Add Context' section explaining that .cursorrules and .clinerules are automatically added, how to customize them via aica.toml, and support for .cursor/rules/*.mdc files. |
| enhance | Modified the default configuration in src/config.ts to include '.cursorrules' and '.clinerules' in the rules files array, ensuring these files are automatically processed. |
| bugfix | Changed rules-finder.ts to check if a file exists before attempting to read its content, preventing potential errors with missing files. |