### PR TITLE
test: add unit tests for file listing and gitignore pattern matching

### DIFF
--- a/src/llmcontext/system-environment.internal.test.ts
+++ b/src/llmcontext/system-environment.internal.test.ts
@@ -1,0 +1,73 @@
+import { describe, test, expect } from "bun:test";
+import {
+  composeIgnorePatterns,
+  matchGitignorePattern,
+  matchesAnyIgnorePattern,
+} from "./system-environment";
+
+describe("system-environment internal tests", () => {
+  describe("matchGitignorePattern()", () => {
+    test("should match simple pattern without slash", () => {
+      expect(matchGitignorePattern("foo.txt", "foo.txt")).toBe(true);
+      expect(matchGitignorePattern("foo.txt", "bar/foo.txt")).toBe(true);
+      expect(matchGitignorePattern("*.txt", "bar/foo.txt")).toBe(true);
+    });
+
+    test("should handle wildcards and negative patterns", () => {
+      // Test matchGitignorePattern function in isolation
+      // For patterns like *.log
+      expect(matchGitignorePattern("*.log", "error.log")).toBe(true);
+      expect(matchGitignorePattern("!error.log", "error.log")).toBe(false);
+      // Note: The '!' is actually handled by matchesAnyIgnorePattern's internal logic
+      // but we verify the behavior here anyway
+    });
+  });
+
+  describe("composeIgnorePatterns()", () => {
+    test("should combine defaultIgnorePatterns and .gitignore patterns", () => {
+      // Using dummy defaultIgnorePatterns and test directory (pseudo)
+      // Since this actually reads from the filesystem, we'll keep this test shallow
+      const defaultPatterns = ["node_modules", "dist"];
+      const combined = composeIgnorePatterns("/dummy/path", defaultPatterns);
+
+      // Check if the return value is an array of patterns
+      expect(Array.isArray(combined)).toBe(true);
+      // Roughly verify that defaultIgnorePatterns are included
+      expect(combined.find((p) => p.pattern === "node_modules")).toBeTruthy();
+      expect(combined.find((p) => p.pattern === "dist")).toBeTruthy();
+    });
+  });
+
+  describe("matchesAnyIgnorePattern()", () => {
+    test("should ignore matching patterns", () => {
+      const combined = [
+        { pattern: "node_modules", isNegative: false },
+        { pattern: "temp/", isNegative: false },
+        { pattern: "src/temp/", isNegative: true }, // Negative pattern to "revive" the path
+      ];
+      // src/temp/hello.txt could be ignored by "temp/" or "node_modules"
+      // but "src/temp/" appears later as a negative pattern -> revived and not ignored
+      expect(matchesAnyIgnorePattern(combined, "src/temp/hello.txt")).toBe(
+        false,
+      );
+
+      // node_modules/package.json is normally ignored
+      expect(
+        matchesAnyIgnorePattern(combined, "node_modules/package.json"),
+      ).toBe(true);
+
+      // foo.js doesn't match any pattern -> not ignored
+      expect(matchesAnyIgnorePattern(combined, "foo.js")).toBe(false);
+    });
+
+    test("should handle wildcard patterns like *.txt", () => {
+      const patterns = [
+        { pattern: "*.txt", isNegative: false },
+        { pattern: "secret.txt", isNegative: true }, // secret.txt is revived
+      ];
+      expect(matchesAnyIgnorePattern(patterns, "test.txt")).toBe(true);
+      expect(matchesAnyIgnorePattern(patterns, "secret.txt")).toBe(false);
+      expect(matchesAnyIgnorePattern(patterns, "image.png")).toBe(false);
+    });
+  });
+});

--- a/src/llmcontext/system-environment.test.ts
+++ b/src/llmcontext/system-environment.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
-import { listFiles } from "./system-environment";
+import { listFiles, ListFilesResult } from "./system-environment";
 import { mkdir, writeFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 
@@ -78,71 +78,76 @@ debug/**/debug.log
   });
 
   test("should list files with limit", () => {
-    const result = listFiles(testDir, 2);
-    expect(result).toHaveLength(2);
+    const result: ListFilesResult = listFiles(testDir, 2);
+    expect(result.files).toHaveLength(2);
   });
 
   test("should ignore files in defaultIgnorePatterns", () => {
-    const result = listFiles(testDir, 100);
+    const result: ListFilesResult = listFiles(testDir, 100);
+    const files = result.files;
 
     // node_modules and .env files should be ignored
-    const hasNodeModules = result.some((path) => path.includes("node_modules"));
-    const hasEnvFile = result.some((path) => path.includes(".env"));
+    const hasNodeModules = files.some((path) => path.includes("node_modules"));
+    const hasEnvFile = files.some((path) => path.includes(".env"));
     expect(hasNodeModules).toBe(false);
     expect(hasEnvFile).toBe(false);
 
     // Regular files should be included
-    const hasFile1 = result.some((path) => path.includes("file1.txt"));
-    const hasFile2 = result.some((path) => path.includes("file2.txt"));
+    const hasFile1 = files.some((path) => path.includes("file1.txt"));
+    const hasFile2 = files.some((path) => path.includes("file2.txt"));
     expect(hasFile1).toBe(true);
     expect(hasFile2).toBe(true);
   });
 
   describe("gitignore patterns", () => {
-    // Basic gitignore test
     test("basic ignore patterns", () => {
-      const result = listFiles(testDir, 100);
+      const result: ListFilesResult = listFiles(testDir, 100);
+      const files = result.files;
       // Basic ignore patterns
-      expect(result.some((p) => p.includes("ignored-by-gitignore.txt"))).toBe(
+      expect(files.some((p) => p.includes("ignored-by-gitignore.txt"))).toBe(
         false,
       );
-      expect(result.some((p) => p.includes("temp/temp-file.txt"))).toBe(false);
-      expect(result.some((p) => p.endsWith(".log"))).toBe(false);
+      expect(files.some((p) => p.includes("temp/temp-file.txt"))).toBe(false);
+      expect(files.some((p) => p.endsWith(".log"))).toBe(false);
     });
 
     test("prefix patterns", () => {
-      const result = listFiles(testDir, 100);
+      const result: ListFilesResult = listFiles(testDir, 100);
+      const files = result.files;
       // Path prefix
-      expect(result.some((p) => p.includes("/build/"))).toBe(false);
-      expect(result.some((p) => p.includes("doc/frotz/"))).toBe(false);
+      expect(files.some((p) => p.includes("/build/"))).toBe(false);
+      expect(files.some((p) => p.includes("doc/frotz/"))).toBe(false);
     });
 
     test("negative patterns", () => {
-      const result = listFiles(testDir, 100);
+      const result: ListFilesResult = listFiles(testDir, 100);
+      const files = result.files;
       // Negative patterns
-      expect(result.some((p) => p.includes("src/temp/hello.txt"))).toBe(true);
-      expect(result.some((p) => p.includes("src/hello.txt"))).toBe(true);
+      expect(files.some((p) => p.includes("src/temp/hello.txt"))).toBe(true);
+      expect(files.some((p) => p.includes("src/hello.txt"))).toBe(true);
     });
 
     test("wildcard patterns", () => {
-      const result = listFiles(testDir, 100);
+      const result: ListFilesResult = listFiles(testDir, 100);
+      const files = result.files;
       // Wildcard patterns
-      expect(result.some((p) => p.endsWith(".o"))).toBe(false);
-      expect(result.some((p) => p.endsWith(".tmp"))).toBe(false);
+      expect(files.some((p) => p.endsWith(".o"))).toBe(false);
+      expect(files.some((p) => p.endsWith(".tmp"))).toBe(false);
     });
 
     test("** patterns", () => {
-      const result = listFiles(testDir, 100);
+      const result: ListFilesResult = listFiles(testDir, 100);
+      const files = result.files;
       // ** patterns
-      expect(result.some((p) => p.includes("debug/a/b/c/debug.log"))).toBe(
+      expect(files.some((p) => p.includes("debug/a/b/c/debug.log"))).toBe(
         false,
       );
     });
   });
 
   test("should return absolute paths", () => {
-    const result = listFiles(testDir, 10);
-    result.forEach((path) => {
+    const result: ListFilesResult = listFiles(testDir, 10);
+    result.files.forEach((path) => {
       expect(path.startsWith("/")).toBe(true);
     });
   });

--- a/src/llmcontext/system-environment.test.ts
+++ b/src/llmcontext/system-environment.test.ts
@@ -1,0 +1,149 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { listFiles } from "./system-environment";
+import { mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+
+describe("listFiles", () => {
+  const testDir = join(import.meta.dir, "test-files");
+  const files = [
+    "file1.txt",
+    "file2.txt",
+    ".env",
+    "node_modules/package.json",
+    "src/test.ts",
+    "src/deep/test.ts",
+    "ignored-by-gitignore.txt",
+    "temp/temp-file.txt",
+    "doc/frotz/test.txt",
+    "a/doc/frotz/test.txt",
+    "build/hello.txt",
+    "src/hello.txt",
+    "src/hello.o",
+    "src/hello.tmp",
+    "src/temp/hello.txt",
+    "debug/a/b/c/debug.log",
+  ];
+
+  beforeAll(async () => {
+    // Setup: Create test directories and files
+    await mkdir(testDir, { recursive: true });
+    await mkdir(join(testDir, "src", "deep"), { recursive: true });
+    await mkdir(join(testDir, "node_modules"), { recursive: true });
+    await mkdir(join(testDir, "temp"), { recursive: true });
+    await mkdir(join(testDir, "doc", "frotz"), { recursive: true });
+    await mkdir(join(testDir, "a", "doc", "frotz"), { recursive: true });
+    await mkdir(join(testDir, "build"), { recursive: true });
+    await mkdir(join(testDir, "src", "temp"), { recursive: true });
+    await mkdir(join(testDir, "debug", "a", "b", "c"), { recursive: true });
+
+    // Create .gitignore file
+    await writeFile(
+      join(testDir, ".gitignore"),
+      `
+# Comments are ignored
+ignored-by-gitignore.txt
+temp/
+*.log
+
+# Path prefix tests
+/build/
+doc/frotz/
+
+# Wildcard tests
+**/*.o
+**/*.tmp
+
+# Negative pattern tests
+src/temp/
+!src/temp/hello.txt
+
+# Multiple * tests
+debug/**/debug.log
+`,
+    );
+
+    // Create test files
+    for (const file of files) {
+      const filePath = join(testDir, file);
+      await writeFile(filePath, "test content");
+    }
+
+    // Create log file that matches .gitignore pattern
+    await writeFile(join(testDir, "test.log"), "log content");
+  });
+
+  afterAll(async () => {
+    // Clean up: Delete test directory
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  test("should list files with limit", () => {
+    const result = listFiles(testDir, 2);
+    expect(result).toHaveLength(2);
+  });
+
+  test("should ignore files in defaultIgnorePatterns", () => {
+    const result = listFiles(testDir, 100);
+
+    // node_modules and .env files should be ignored
+    const hasNodeModules = result.some((path) => path.includes("node_modules"));
+    const hasEnvFile = result.some((path) => path.includes(".env"));
+    expect(hasNodeModules).toBe(false);
+    expect(hasEnvFile).toBe(false);
+
+    // Regular files should be included
+    const hasFile1 = result.some((path) => path.includes("file1.txt"));
+    const hasFile2 = result.some((path) => path.includes("file2.txt"));
+    expect(hasFile1).toBe(true);
+    expect(hasFile2).toBe(true);
+  });
+
+  describe("gitignore patterns", () => {
+    // Basic gitignore test
+    test("basic ignore patterns", () => {
+      const result = listFiles(testDir, 100);
+      // Basic ignore patterns
+      expect(result.some((p) => p.includes("ignored-by-gitignore.txt"))).toBe(
+        false,
+      );
+      expect(result.some((p) => p.includes("temp/temp-file.txt"))).toBe(false);
+      expect(result.some((p) => p.endsWith(".log"))).toBe(false);
+    });
+
+    test("prefix patterns", () => {
+      const result = listFiles(testDir, 100);
+      // Path prefix
+      expect(result.some((p) => p.includes("/build/"))).toBe(false);
+      expect(result.some((p) => p.includes("doc/frotz/"))).toBe(false);
+    });
+
+    test("negative patterns", () => {
+      const result = listFiles(testDir, 100);
+      // Negative patterns
+      expect(result.some((p) => p.includes("src/temp/hello.txt"))).toBe(true);
+      expect(result.some((p) => p.includes("src/hello.txt"))).toBe(true);
+    });
+
+    test("wildcard patterns", () => {
+      const result = listFiles(testDir, 100);
+      // Wildcard patterns
+      expect(result.some((p) => p.endsWith(".o"))).toBe(false);
+      expect(result.some((p) => p.endsWith(".tmp"))).toBe(false);
+    });
+
+    test("** patterns", () => {
+      const result = listFiles(testDir, 100);
+      // ** patterns
+      expect(result.some((p) => p.includes("debug/a/b/c/debug.log"))).toBe(
+        false,
+      );
+    });
+  });
+
+  test("should return absolute paths", () => {
+    const result = listFiles(testDir, 10);
+    result.forEach((path) => {
+      expect(path.startsWith("/")).toBe(true);
+    });
+  });
+});

--- a/src/llmcontext/system-environment.ts
+++ b/src/llmcontext/system-environment.ts
@@ -1,7 +1,8 @@
 import { toPosixPath } from "@/utility/path";
-import { readdirSync } from "fs";
+import { readdirSync, statSync, existsSync, readFileSync } from "fs";
 import os from "os";
 import osName from "os-name";
+import { join, relative } from "path";
 
 function getShellFromEnv(): string | null {
   const { env } = process;
@@ -40,14 +41,175 @@ export function getSystemInfoSection(cwd: string): string {
 
 export function getEnvironmentDetailsPrompt(cwd: string): string {
   // list all files in the cwd
-  const files = readdirSync(cwd);
-  const filesString = files.map((file) => `<file>${file}</file>`).join("\n");
+  const { files: absolutePathFiles, didHitLimit } = listFiles(cwd, 200);
+  const relativePathFiles = absolutePathFiles.map((file) =>
+    relative(cwd, file),
+  );
+  const filesString = relativePathFiles
+    .map((file) => `<file>${file}</file>`)
+    .join("\n");
 
   return `
-  <environment_details>
-  Running on CI: ${process.env.CI || "false"}
-  Working Directory: ${cwd}
-  Top Level Files:
-  ${filesString}
-  </environment_details>`;
+<environment_details>
+Running on CI: ${process.env.CI || "false"}
+Working Directory: ${cwd}
+<files>
+${filesString}
+</files>
+${
+  didHitLimit
+    ? "The list of files was truncated. Use list_files on specific subdirectories if you need to explore further."
+    : ""
+}
+</environment_details>`;
+}
+
+const defaultIgnorePatterns = [
+  "node_modules",
+  "dist",
+  "build",
+  "coverage",
+  "logs",
+  "tmp",
+  "cache",
+  "temp",
+  "bundle",
+  "vendor",
+  "out",
+  "__pycache__",
+  "venv",
+  ".venv",
+  ".gitignore",
+  ".git",
+  ".DS_Store",
+  ".vscode",
+  ".idea",
+  ".env",
+  ".env.*",
+];
+
+export function composeIgnorePatterns(
+  cwd: string,
+  defaultIgnorePatterns: string[],
+): { pattern: string; isNegative: boolean }[] {
+  const combinedPatterns: { pattern: string; isNegative: boolean }[] = [];
+
+  // 1. First, add defaultIgnorePatterns
+  for (const p of defaultIgnorePatterns) {
+    combinedPatterns.push({ pattern: p, isNegative: false });
+  }
+
+  // 2. If .gitignore exists, read and add its patterns
+  const gitignorePath = join(cwd, ".gitignore");
+  if (existsSync(gitignorePath)) {
+    const gitignoreContent = readFileSync(gitignorePath, "utf-8");
+    combinedPatterns.push(
+      ...gitignoreContent
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line && !line.startsWith("#"))
+        .map((pattern) => ({
+          pattern: pattern.startsWith("!") ? pattern.slice(1) : pattern,
+          isNegative: pattern.startsWith("!"),
+        })),
+    );
+  }
+
+  return combinedPatterns;
+}
+
+export function matchesAnyIgnorePattern(
+  combinedPatterns: { pattern: string; isNegative: boolean }[],
+  normalizedRelativePath: string,
+): boolean {
+  let isIgnored = false;
+
+  for (const { pattern, isNegative } of combinedPatterns) {
+    if (matchGitignorePattern(pattern, normalizedRelativePath)) {
+      if (isNegative) {
+        isIgnored = false;
+      } else {
+        isIgnored = true;
+      }
+    }
+  }
+  return isIgnored;
+}
+
+export function matchGitignorePattern(pattern: string, path: string): boolean {
+  let regexPattern = pattern;
+  regexPattern = regexPattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+  regexPattern = regexPattern.replace(/\*\*/g, "{{GLOBSTAR}}");
+  regexPattern = regexPattern.replace(/\*/g, "[^/]*");
+  regexPattern = regexPattern.replace(/{{GLOBSTAR}}/g, ".*");
+
+  if (pattern.startsWith("/")) {
+    regexPattern = `^${regexPattern.slice(1)}`;
+  } else if (pattern.endsWith("/")) {
+    regexPattern = `(^|.*/)${regexPattern}.*$`;
+  } else if (pattern.includes("/")) {
+    regexPattern = `(^|.*/)${regexPattern}(/.*)?$`;
+  } else {
+    regexPattern = `(^|.*/)(${regexPattern})(/.*)?$`;
+  }
+
+  try {
+    const regex = new RegExp(regexPattern);
+    return regex.test(path);
+  } catch (error) {
+    console.error(`Invalid regex pattern: ${regexPattern}`, error);
+    return false;
+  }
+}
+
+export type ListFilesResult = {
+  files: string[];
+  didHitLimit: boolean;
+};
+export function listFiles(cwd: string, limit: number): ListFilesResult {
+  const result: string[] = [];
+  // composeIgnorePatterns に切り出した
+  const combinedPatterns = composeIgnorePatterns(cwd, defaultIgnorePatterns);
+
+  function shouldIgnore(path: string): boolean {
+    const relativePath = relative(cwd, path);
+    if (!relativePath) return false;
+
+    const normalizedRelativePath = relativePath.replace(/\\/g, "/");
+    return matchesAnyIgnorePattern(combinedPatterns, normalizedRelativePath);
+  }
+
+  function traverseDirectory(currentPath: string): boolean {
+    if (result.length >= limit) return true;
+
+    try {
+      const entries = readdirSync(currentPath);
+      const sortedEntries = entries.sort();
+
+      for (const entry of sortedEntries) {
+        if (result.length >= limit) break;
+
+        const fullPath = join(currentPath, entry);
+        const stats = statSync(fullPath);
+
+        // Directory: we go inside even if it matches ignore patterns, because some files could be excluded from ignore by a negative pattern
+        if (stats.isDirectory()) {
+          traverseDirectory(fullPath);
+        } else if (stats.isFile()) {
+          // File: we check the ignore pattern here
+          if (shouldIgnore(fullPath)) continue;
+          result.push(fullPath);
+        }
+      }
+    } catch (error) {
+      console.error(`Error reading directory ${currentPath}:`, error);
+    }
+    return false;
+  }
+
+  const didHitLimit = traverseDirectory(cwd);
+  return {
+    files: result,
+    didHitLimit,
+  };
 }


### PR DESCRIPTION
<!-- AICA GENERATED -->
## Summary

| Category | Description |
|---|---|
| feature | Add new test files ('system-environment.internal.test.ts' and 'system-environment.test.ts') to validate gitignore pattern matching and file listing functionality. |
| enhance | Update getEnvironmentDetailsPrompt to use the new listFiles function for recursively listing files with a limit and converting them to relative paths, as well as displaying a truncation warning. |
| enhance | Introduce default ignore patterns and the function composeIgnorePatterns that merges these with '.gitignore' entries, allowing flexible file exclusion. |
| enhance | Implement and improve ignore pattern matching via matchesAnyIgnorePattern and matchGitignorePattern functions, supporting wildcards, negative patterns, and path prefixes. |
| feature | Add a new listFiles function that recursively traverses directories, applies the ignore patterns, sorts directory entries, and respects a file count limit. |