### PR TITLE
feat: add MCP (Model Context Protocol) support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 knowledge-src.db
 knowledge-doc.db
 aica.toml
+mcp.json
 tmp/
 
 # Logs

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ So, I decided to create a new tool with the following characteristics:
 
 - [x] AI Coding Agent
 - [x] AI Code Review
+- [x] MCP(Model Context Protocol) supported. stdio and SSE transports are supported.
 - [x] Automatic knowledge retrieving for code review
 - [x] Symbol based code search for retrieving knowledge
 - [x] Vector based document search for retrieving knowledge
@@ -246,6 +247,35 @@ If you want to customize the context, configure the [rules] section in aica.toml
 
 Additionally, .cursor/rules/\*.mdc files are supported by default.
 This function can be disabled through the settings.
+
+## MCP(Model Context Protocol)
+
+create a mcp.json file to define the MCP server.
+
+example:
+
+```json
+[
+  {
+    "name": "example-server",
+    "type": "stdio",
+    "command": "node",
+    "args": ["./server.js"]
+  },
+  {
+    "name": "example-server",
+    "type": "sse",
+    "url": "http://localhost:3001/sse"
+  }
+]
+```
+
+set `setupFile` in aica.toml like below.
+
+```toml
+[mcp]
+setupFile = "mcp.json"
+```
 
 ## GitHub Actions
 

--- a/aica.example.toml
+++ b/aica.example.toml
@@ -149,3 +149,24 @@ draft = false
 
 [chat]
 system = "You are a helpful assistant. Answer the user's question."
+
+[mcp]
+# MCP setup file is a JSON file that describes the MCP server.
+#
+# Example:
+# [{
+#     "name": "product",
+#     "type": "stdio",
+#     "command": "node",
+#     "args": ["./server2.js"]
+# },
+# {
+#     "name": "product",
+#     "type": "sse",
+#     "url": "http://localhost:3001/sse"
+# }
+#]
+#
+# path to MCP setup file
+# setupFile = "mcp.json"
+setupFile = ""

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "dependencies": {
         "@actions/core": "^1.11.1",
         "@actions/github": "^6.0.0",
+        "@modelcontextprotocol/sdk": "^1.5.0",
         "@octokit/core": "^6.1.4",
         "@octokit/plugin-rest-endpoint-methods": "^13.3.1",
         "@orama/orama": "^2.1.1",
@@ -55,6 +56,8 @@
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.5.0", "", { "dependencies": { "content-type": "^1.0.5", "eventsource": "^3.0.2", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-IJ+5iVVs8FCumIHxWqpwgkwOzyhtHVKy45s6Ug7Dv0MfRpaYisH8QQ87rIWeWdOzlk8sfhitZ7HCyQZk7d6b8w=="],
 
     "@msgpack/msgpack": ["@msgpack/msgpack@2.8.0", "", {}, "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ=="],
 
@@ -180,6 +183,8 @@
 
     "bun-types": ["bun-types@1.2.2", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-RCbMH5elr9gjgDGDhkTTugA21XtJAy/9jkKe/G3WR2q17VPGhcquf9Sir6uay9iW+7P/BV0CAHA1XlHXMAVKHg=="],
 
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
@@ -206,6 +211,8 @@
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "css-selector-parser": ["css-selector-parser@1.4.1", "", {}, "sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g=="],
@@ -219,6 +226,8 @@
     "default-shell": ["default-shell@2.2.0", "", {}, "sha512-sPpMZcVhRQ0nEMDtuMJ+RtCxt7iHPAMBU+I4tAlo5dU1sjRpNax0crj6nR3qKpvVnckaQ9U38enXcwW9nZJeCw=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "deprecation": ["deprecation@2.3.1", "", {}, "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="],
 
@@ -241,6 +250,10 @@
     "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
+    "eventsource": ["eventsource@3.0.5", "", { "dependencies": { "eventsource-parser": "^3.0.0" } }, "sha512-LT/5J605bx5SNyE+ITBDiM3FxffBiq9un7Vx0EwMDM3vg8sWKx/tO2zC+LMqZ+smAM0F2hblaDZUVZF0te2pSw=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.0", "", {}, "sha512-T1C0XCUimhxVQzW4zFipdx0SficT651NnkR0ZSH3yQwh+mFMdLfgjABVi4YtMTtaL4s168593DaoaRLMqryavA=="],
 
     "execa": ["execa@8.0.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^8.0.1", "human-signals": "^5.0.0", "is-stream": "^3.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^5.1.0", "onetime": "^6.0.0", "signal-exit": "^4.1.0", "strip-final-newline": "^3.0.0" } }, "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg=="],
 
@@ -320,9 +333,13 @@
 
     "html-void-elements": ["html-void-elements@2.0.1", "", {}, "sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A=="],
 
+    "http-errors": ["http-errors@2.0.0", "", { "dependencies": { "depd": "2.0.0", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": "2.0.1", "toidentifier": "1.0.1" } }, "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ=="],
+
     "human-signals": ["human-signals@5.0.0", "", {}, "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ=="],
 
     "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "ignore": ["ignore@7.0.3", "", {}, "sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA=="],
 
@@ -476,6 +493,8 @@
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
+    "raw-body": ["raw-body@3.0.0", "", { "dependencies": { "bytes": "3.1.2", "http-errors": "2.0.0", "iconv-lite": "0.6.3", "unpipe": "1.0.0" } }, "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g=="],
+
     "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
@@ -552,6 +571,10 @@
 
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
 
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
@@ -570,6 +593,8 @@
 
     "stack-trace": ["stack-trace@0.0.10", "", {}, "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="],
 
+    "statuses": ["statuses@2.0.1", "", {}, "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="],
+
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
@@ -583,6 +608,8 @@
     "text-hex": ["text-hex@1.0.0", "", {}, "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
@@ -621,6 +648,8 @@
     "unist-util-visit-parents": ["unist-util-visit-parents@5.1.3", "", { "dependencies": { "@types/unist": "^2.0.0", "unist-util-is": "^5.0.0" } }, "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg=="],
 
     "universal-user-agent": ["universal-user-agent@7.0.2", "", {}, "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
@@ -662,6 +691,8 @@
 
     "zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
 
+    "zod-to-json-schema": ["zod-to-json-schema@3.24.3", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-HIAfWdYIt1sssHfYZFCXp4rU1w2r8hVVXYIlmoa0r0gABLs5di3RCqPU5DDROogVz1pAdYBaz7HK5n9pSUNs3A=="],
+
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@actions/github/@octokit/core": ["@octokit/core@5.2.0", "", { "dependencies": { "@octokit/auth-token": "^4.0.0", "@octokit/graphql": "^7.1.0", "@octokit/request": "^8.3.1", "@octokit/request-error": "^5.1.0", "@octokit/types": "^13.0.0", "before-after-hook": "^2.2.0", "universal-user-agent": "^6.0.0" } }, "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg=="],
@@ -676,9 +707,13 @@
 
     "color-string/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
     "execa/is-stream": ["is-stream@3.0.0", "", {}, "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="],
 
     "hast-util-raw/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
+
+    "humanize-ms/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "scripts": {
     "start": "bun run src/main.ts",
     "build": "bun build --compile --outfile dist/aica src/main.ts",
-    "build:actions": "bun build --compile --outfile dist/actions-runner src/actions-runner.ts",
-    "postinstall": "bun run build"
+    "build:actions": "bun build --compile --outfile dist/actions-runner src/actions-runner.ts"
   },
   "devDependencies": {
     "@types/bun": "latest",
@@ -23,6 +22,7 @@
   "dependencies": {
     "@actions/core": "^1.11.1",
     "@actions/github": "^6.0.0",
+    "@modelcontextprotocol/sdk": "^1.5.0",
     "@octokit/core": "^6.1.4",
     "@octokit/plugin-rest-endpoint-methods": "^13.3.1",
     "@orama/orama": "^2.1.1",

--- a/src/actions/edit.ts
+++ b/src/actions/edit.ts
@@ -21,8 +21,7 @@ export async function performEdit(
   }
   const gitRepository = new GitRepository(repoDir);
   const llm = createLLM(config.llm);
-  const rulesConfig = config.rules;
-  const agent = new Agent(gitRepository, llm, rulesConfig);
+  await using agent = new Agent(gitRepository, llm, config);
 
   try {
     // Edit a file

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -108,11 +108,11 @@ export class Agent implements AsyncDisposable {
     let mcpPrompt = "=== Available MCP Servers ===\n";
     if (this.mcpClientManager) {
       mcpPrompt +=
-        "You can use the server tool or resource using use_mcp_tool or use_mcp_resource.";
+        "You can use the MCP server tool and resource using use_mcp_tool and use_mcp_resource.";
       mcpPrompt += this.mcpClientManager.getInstructionPrompt();
     } else {
       mcpPrompt +=
-        "No MCP servers are available. You can not use use_mcp_tool or use_mcp_resource.";
+        "No MCP servers are available. You can not use use_mcp_tool and use_mcp_resource.";
     }
     let prompt = await getSystemPrompt(
       process.cwd(),

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -3,10 +3,19 @@ import { LLM, Message } from "@/llm/mod";
 import { AgentHistory } from "./agent-history";
 import { MessageBlock, parseAssistantMessage } from "./assistant-message";
 import { getSystemPrompt } from "./prompt/system-prompt";
-import { ActionResult, executeTool, generateAvailableTools } from "./tool/mod";
+import {
+  ActionResult,
+  createToolExecutionContext,
+  executeTool,
+  generateAvailableTools,
+  initializeTools,
+  Tool,
+  ToolExecutionContext,
+} from "./tool/mod";
 import { Source } from "@/source";
 import { getEnvironmentDetailsPrompt } from "@/llmcontext/system-environment";
 import { Config, RulesConfig } from "@/config";
+import { MCPClientManager } from "@/mcp/client-manager";
 
 export type TaskExecutionOptions = {
   verbose: boolean;
@@ -22,20 +31,20 @@ export type PlanResult = {
   response: string;
 };
 
-export class Agent {
+export class Agent implements AsyncDisposable {
   private gitRepository: GitRepository;
   private llm: LLM;
   private rulesConfig: RulesConfig;
   private history: AgentHistory;
   private messages: Message[] = [];
   private referencedFiles: Map<string, Source> = new Map();
+  private mcpClientManager: MCPClientManager | null = null;
+  private tools: Record<string, Tool>;
+  private toolExecutionContext: ToolExecutionContext;
 
-  constructor(
-    gitRepository: GitRepository,
-    llm: LLM,
-    rulesConfig: RulesConfig,
-  ) {
-    this.rulesConfig = rulesConfig;
+  constructor(gitRepository: GitRepository, llm: LLM, config: Config) {
+    this.tools = initializeTools();
+    this.rulesConfig = config.rules;
     this.gitRepository = gitRepository;
     this.llm = llm;
     this.history = new AgentHistory();
@@ -44,6 +53,30 @@ export class Agent {
       role: "user",
       content: getEnvironmentDetailsPrompt(process.cwd()),
     });
+
+    if (config.mcp.setupFile) {
+      this.mcpClientManager = new MCPClientManager(config.mcp.setupFile);
+    }
+    this.toolExecutionContext = createToolExecutionContext(
+      this.mcpClientManager,
+    );
+    this.start();
+  }
+
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.close();
+  }
+
+  private async start(): Promise<void> {
+    if (this.mcpClientManager) {
+      await this.mcpClientManager.start();
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.mcpClientManager) {
+      await this.mcpClientManager.stop();
+    }
   }
 
   async plan(prompt: string): Promise<PlanResult> {
@@ -72,14 +105,24 @@ export class Agent {
   }
 
   private async createSystemPrompt(): Promise<string> {
-    return getSystemPrompt(
+    let mcpPrompt = "";
+    if (this.mcpClientManager) {
+      mcpPrompt =
+        "=== Available MCP Servers ===\n" +
+        "You can use the server tool or resource using use_mcp_tool or use_mcp_resource.";
+      mcpPrompt = this.mcpClientManager.getInstructionPrompt();
+    }
+    let prompt = await getSystemPrompt(
       process.cwd(),
       this.rulesConfig,
       this.gitRepository.gitRootDir,
-      generateAvailableTools(),
+      generateAvailableTools(this.tools),
+      mcpPrompt,
       this.history.toPromptString(),
       this.referencedFiles,
     );
+
+    return prompt;
   }
 
   async startTask(
@@ -116,7 +159,11 @@ export class Agent {
               } Params: ${JSON.stringify(block.action.params, null, 2)}`,
             );
           }
-          const toolExecutionResult = await executeTool(block.action);
+          const toolExecutionResult = await executeTool(
+            this.toolExecutionContext,
+            this.tools,
+            block.action,
+          );
           if (toolExecutionResult.addedFiles) {
             toolExecutionResult.addedFiles.forEach((file) =>
               this.addFile(file),
@@ -136,10 +183,11 @@ export class Agent {
         }
       }
       if (!hasActionResult) {
+        console.warn("No action found. agent will stop.");
         break;
       }
       prompt =
-        "Please evaluate the task content and the tool’s execution results. Only consider the next action if it is necessary to continue the task.";
+        "Please evaluate the task content and the tool's execution results. Only consider the next action if it is necessary to continue the task.";
     }
   }
 }

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -105,12 +105,14 @@ export class Agent implements AsyncDisposable {
   }
 
   private async createSystemPrompt(): Promise<string> {
-    let mcpPrompt = "";
+    let mcpPrompt = "=== Available MCP Servers ===\n";
     if (this.mcpClientManager) {
-      mcpPrompt =
-        "=== Available MCP Servers ===\n" +
+      mcpPrompt +=
         "You can use the server tool or resource using use_mcp_tool or use_mcp_resource.";
-      mcpPrompt = this.mcpClientManager.getInstructionPrompt();
+      mcpPrompt += this.mcpClientManager.getInstructionPrompt();
+    } else {
+      mcpPrompt +=
+        "No MCP servers are available. You can not use use_mcp_tool or use_mcp_resource.";
     }
     let prompt = await getSystemPrompt(
       process.cwd(),

--- a/src/agent/prompt/system-prompt.ts
+++ b/src/agent/prompt/system-prompt.ts
@@ -8,6 +8,7 @@ export async function getSystemPrompt(
   rulesConfig: RulesConfig,
   gitRoot: string,
   availableToolsPrompt: string,
+  mcpPrompt: string,
   historyPrompt: string,
   referencedFiles: Map<string, Source>,
 ): Promise<string> {
@@ -24,6 +25,7 @@ ${getCapabilitiesSection(cwd)}
 ${getRulesSection(cwd)}
 ${rulesPrompt}
 ${availableToolsPrompt}
+${mcpPrompt}
 
 === History ===
 ${historyPrompt}

--- a/src/agent/tool/tools/ask-followup-question.ts
+++ b/src/agent/tool/tools/ask-followup-question.ts
@@ -1,4 +1,10 @@
-import { Tool, ToolError, ToolExecutionResult, ToolId } from "../tool";
+import {
+  Tool,
+  ToolError,
+  ToolExecutionContext,
+  ToolExecutionResult,
+  ToolId,
+} from "../tool";
 
 export class AskFollowupQuestionTool implements Tool {
   name: ToolId = "ask_followup_question";
@@ -17,7 +23,10 @@ export class AskFollowupQuestionTool implements Tool {
 </ask_followup_question>
 `.trim();
 
-  async execute(args: { question: string }): Promise<ToolExecutionResult> {
+  async execute(
+    context: ToolExecutionContext,
+    args: { question: string },
+  ): Promise<ToolExecutionResult> {
     if (!args.question) {
       throw new ToolError("Question is required");
     }

--- a/src/agent/tool/tools/attempt-completion.ts
+++ b/src/agent/tool/tools/attempt-completion.ts
@@ -1,4 +1,10 @@
-import { Tool, ToolError, ToolExecutionResult, ToolId } from "../tool";
+import {
+  Tool,
+  ToolError,
+  ToolExecutionContext,
+  ToolExecutionResult,
+  ToolId,
+} from "../tool";
 
 export class AttemptCompletionTool implements Tool {
   name: ToolId = "attempt_completion";
@@ -23,10 +29,13 @@ export class AttemptCompletionTool implements Tool {
 </attempt_completion>
 `.trim();
 
-  async execute(args: {
-    result: string;
-    command: string;
-  }): Promise<ToolExecutionResult> {
+  async execute(
+    context: ToolExecutionContext,
+    args: {
+      result: string;
+      command: string;
+    },
+  ): Promise<ToolExecutionResult> {
     if (!args.result) {
       throw new ToolError("Result is required");
     }

--- a/src/agent/tool/tools/create-file.ts
+++ b/src/agent/tool/tools/create-file.ts
@@ -1,5 +1,11 @@
 import { Source } from "@/source";
-import { Tool, ToolError, ToolExecutionResult, ToolId } from "../tool";
+import {
+  Tool,
+  ToolError,
+  ToolExecutionContext,
+  ToolExecutionResult,
+  ToolId,
+} from "../tool";
 
 export class CreateFileTool implements Tool {
   name: ToolId = "create_file";
@@ -15,10 +21,13 @@ export class CreateFileTool implements Tool {
     },
   };
 
-  async execute(args: {
-    file: string;
-    content: string;
-  }): Promise<ToolExecutionResult> {
+  async execute(
+    context: ToolExecutionContext,
+    args: {
+      file: string;
+      content: string;
+    },
+  ): Promise<ToolExecutionResult> {
     if (!args.file) {
       throw new ToolError("File path is required");
     }

--- a/src/agent/tool/tools/edit-file.ts
+++ b/src/agent/tool/tools/edit-file.ts
@@ -1,5 +1,11 @@
 import { Source } from "@/source";
-import { Tool, ToolError, ToolExecutionResult, ToolId } from "../tool";
+import {
+  Tool,
+  ToolError,
+  ToolExecutionContext,
+  ToolExecutionResult,
+  ToolId,
+} from "../tool";
 import {
   applyPatch,
   checkPatchFormat,
@@ -23,10 +29,13 @@ export class EditFileTool implements Tool {
     },
   };
 
-  async execute(args: {
-    file: string;
-    patch: string;
-  }): Promise<ToolExecutionResult> {
+  async execute(
+    context: ToolExecutionContext,
+    args: {
+      file: string;
+      patch: string;
+    },
+  ): Promise<ToolExecutionResult> {
     if (!args.file || !args.patch) {
       throw new ToolError("File path and patch are required");
     }

--- a/src/agent/tool/tools/execute-command.ts
+++ b/src/agent/tool/tools/execute-command.ts
@@ -1,4 +1,10 @@
-import { Tool, ToolError, ToolExecutionResult, ToolId } from "../tool";
+import {
+  Tool,
+  ToolError,
+  ToolExecutionContext,
+  ToolExecutionResult,
+  ToolId,
+} from "../tool";
 
 export class ExecuteCommandTool implements Tool {
   name: ToolId = "execute_command";
@@ -11,7 +17,10 @@ export class ExecuteCommandTool implements Tool {
     },
   };
 
-  async execute(args: { command: string }): Promise<ToolExecutionResult> {
+  async execute(
+    context: ToolExecutionContext,
+    args: { command: string },
+  ): Promise<ToolExecutionResult> {
     if (!args.command) {
       throw new ToolError("Command is required");
     }

--- a/src/agent/tool/tools/list-files.ts
+++ b/src/agent/tool/tools/list-files.ts
@@ -1,4 +1,10 @@
-import { Tool, ToolError, ToolExecutionResult, ToolId } from "../tool";
+import {
+  Tool,
+  ToolError,
+  ToolExecutionContext,
+  ToolExecutionResult,
+  ToolId,
+} from "../tool";
 import { readdirSync, mkdirSync, existsSync } from "node:fs";
 
 export class ListFilesTool implements Tool {
@@ -13,7 +19,10 @@ export class ListFilesTool implements Tool {
     },
   };
 
-  async execute(args: { directory?: string }): Promise<ToolExecutionResult> {
+  async execute(
+    context: ToolExecutionContext,
+    args: { directory?: string },
+  ): Promise<ToolExecutionResult> {
     const dir = args.directory || ".";
     try {
       if (!existsSync(dir)) {

--- a/src/agent/tool/tools/mcp.ts
+++ b/src/agent/tool/tools/mcp.ts
@@ -1,0 +1,81 @@
+import {
+  Tool,
+  ToolError,
+  ToolExecutionContext,
+  ToolExecutionResult,
+} from "@/agent/tool/tool";
+
+export class UseMcpTool implements Tool {
+  name = "use_mcp_tool";
+  description = "call Mool";
+  params = {
+    serverName: {
+      type: "string",
+      description: "The name of the MCP server to call",
+    },
+    toolName: {
+      type: "string",
+      description: "The name of the MCP tool to call",
+    },
+    args: {
+      type: "object",
+      description:
+        "The arguments to pass to the tool. this value is JSON format." +
+        "restrictly obey the tool's JSON schema.",
+    },
+  };
+
+  async execute(
+    context: ToolExecutionContext,
+    params: Record<string, string>,
+  ): Promise<ToolExecutionResult> {
+    if (!context.mcpClientManager) {
+      throw new ToolError("MCP client manager is not set");
+    }
+    const { serverName, toolName, args } = params;
+    const client = context.mcpClientManager.getClient(serverName);
+    if (!client) {
+      throw new ToolError(`MCP client ${serverName} not found`);
+    }
+    const result = await client.callTool(toolName, JSON.parse(args));
+    return {
+      result:
+        `MCP tool ${serverName}.${toolName} called successfully.\nResult:\n` +
+        `${JSON.stringify(result, null, 2)}`,
+    };
+  }
+}
+export class UseMcpResource implements Tool {
+  name = "use_mcp_resource";
+  description = "get MCP server resource";
+  params = {
+    serverName: {
+      type: "string",
+      description: "The name of the MCP server to get resource",
+    },
+    uri: {
+      type: "string",
+      description: "The uri of the MCP resource to get",
+    },
+  };
+  async execute(
+    context: ToolExecutionContext,
+    params: Record<string, string>,
+  ): Promise<ToolExecutionResult> {
+    if (!context.mcpClientManager) {
+      throw new ToolError("MCP client manager is not set");
+    }
+
+    const { serverName, uri } = params;
+    const client = context.mcpClientManager.getClient(serverName);
+    if (!client) {
+      throw new ToolError(`MCP client ${serverName} not found`);
+    }
+    const resource = await client.readResource(uri);
+    return {
+      result:
+        `MCP resource ${uri} read successfully.\nContent:\n` +
+        `${JSON.stringify(resource, null, 2)}`,
+    };
+  }
+}

--- a/src/agent/tool/tools/read-file.ts
+++ b/src/agent/tool/tools/read-file.ts
@@ -1,4 +1,10 @@
-import { Tool, ToolError, ToolExecutionResult, ToolId } from "../tool";
+import {
+  Tool,
+  ToolError,
+  ToolExecutionContext,
+  ToolExecutionResult,
+  ToolId,
+} from "../tool";
 import { Source } from "@/source";
 
 export class ReadFileTool implements Tool {
@@ -16,7 +22,10 @@ export class ReadFileTool implements Tool {
     },
   };
 
-  async execute(args: { path: string }): Promise<ToolExecutionResult> {
+  async execute(
+    context: ToolExecutionContext,
+    args: { path: string },
+  ): Promise<ToolExecutionResult> {
     if (!args.path) {
       throw new ToolError("File path is required");
     }

--- a/src/agent/tool/tools/search-files.ts
+++ b/src/agent/tool/tools/search-files.ts
@@ -1,4 +1,10 @@
-import { Tool, ToolError, ToolExecutionResult, ToolId } from "../tool";
+import {
+  Tool,
+  ToolError,
+  ToolExecutionContext,
+  ToolExecutionResult,
+  ToolId,
+} from "../tool";
 import { globby } from "globby";
 
 export class SearchFilesTool implements Tool {
@@ -20,11 +26,14 @@ export class SearchFilesTool implements Tool {
     },
   };
 
-  async execute(args: {
-    path: string;
-    regex: string;
-    filePattern?: string;
-  }): Promise<ToolExecutionResult> {
+  async execute(
+    context: ToolExecutionContext,
+    args: {
+      path: string;
+      regex: string;
+      filePattern?: string;
+    },
+  ): Promise<ToolExecutionResult> {
     if (!args.path) {
       throw new ToolError("Directory path is required");
     }

--- a/src/commands/agent-command.ts
+++ b/src/commands/agent-command.ts
@@ -18,7 +18,7 @@ export async function executeAgentCommand(params: any) {
   const config = await readConfig();
   const llm = createLLM(config.llm);
   const gitRepository = new GitRepository(process.cwd());
-  const agent = new Agent(gitRepository, llm, config.rules);
+  await using agent = new Agent(gitRepository, llm, config);
   const isInteractiveMode = prompt === "";
 
   if (values.file) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -79,6 +79,9 @@ export type Config = {
   rules: RulesConfig;
   language: LanguageConfig;
   knowledge?: Knowledge;
+  mcp: {
+    setupFile: string;
+  };
   review: {
     prompt: {
       system: string;
@@ -173,6 +176,9 @@ export const defaultConfig: Config = {
       model: "text-embedding-3-small",
       apiKey: Bun.env.OPENAI_API_KEY || "",
     },
+  },
+  mcp: {
+    setupFile: "",
   },
   review: {
     prompt: {

--- a/src/mcp/__test__/client.test.ts
+++ b/src/mcp/__test__/client.test.ts
@@ -1,0 +1,174 @@
+import { describe, test, expect, beforeEach, mock } from "bun:test";
+import { MCPClient, MCPSetupItem } from "../client";
+import { join } from "path";
+
+// モックの実装
+const mockTransport = {
+  close: () => Promise.resolve(),
+  send: () => Promise.resolve(),
+  onMessage: () => {},
+  onClose: () => {},
+};
+
+const mockClientImplementation = {
+  connect: () => Promise.resolve(),
+  close: () => Promise.resolve(),
+  getServerCapabilities: () =>
+    Promise.resolve({ tools: true, resources: true }),
+  listTools: () => Promise.resolve({ tools: [{ name: "test-tool" }] }),
+  listResources: () =>
+    Promise.resolve({ resources: [{ uri: "test://resource" }] }),
+  callTool: () =>
+    Promise.resolve({
+      content: [
+        {
+          type: "text",
+          text: "Received arg: test-value",
+          mimeType: "text/plain",
+        },
+      ],
+    }),
+  readResource: () =>
+    Promise.resolve({
+      contents: [
+        {
+          uri: "test://resource",
+          text: "Test resource content",
+          mimeType: "text/plain",
+        },
+      ],
+    }),
+};
+
+describe("MCPClient", () => {
+  describe("With Mocked Transport", () => {
+    beforeEach(() => {
+      // トランスポートのモック
+      mock.module("@modelcontextprotocol/sdk/client/sse.js", () => ({
+        SSEClientTransport: class {
+          constructor() {
+            return mockTransport;
+          }
+        },
+      }));
+
+      mock.module("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+        StdioClientTransport: class {
+          constructor() {
+            return mockTransport;
+          }
+        },
+      }));
+
+      // Clientのモック
+      mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
+        Client: class {
+          constructor() {
+            return mockClientImplementation;
+          }
+        },
+      }));
+    });
+
+    describe("SSE Transport", () => {
+      const sseSetup: MCPSetupItem = {
+        name: "test-sse",
+        type: "sse",
+        url: "http://localhost:3000/sse",
+      };
+
+      test("should connect and gather server info", async () => {
+        const client = new MCPClient(sseSetup);
+        await client.connect();
+        await client[Symbol.asyncDispose]();
+      });
+
+      test("should call tool", async () => {
+        const client = new MCPClient(sseSetup);
+        await client.connect();
+
+        const result = await client.callTool("test-tool", {
+          arg: "test-value",
+        });
+        expect(result).toHaveLength(1);
+        expect(result[0].type).toBe("text");
+        expect(result[0].text).toBe("Received arg: test-value");
+
+        await client[Symbol.asyncDispose]();
+      });
+
+      test("should read resource", async () => {
+        const client = new MCPClient(sseSetup);
+        await client.connect();
+
+        const result = await client.readResource("test://resource");
+        expect(result).toHaveLength(1);
+        expect(result[0].uri).toBe("test://resource");
+        expect(result[0].text).toBe("Test resource content");
+
+        await client[Symbol.asyncDispose]();
+      });
+    });
+
+    describe("Stdio Transport", () => {
+      const stdioSetup: MCPSetupItem = {
+        name: "test-stdio",
+        type: "stdio",
+        command: "echo",
+        args: ["test"],
+      };
+
+      test("should connect with stdio transport", async () => {
+        const client = new MCPClient(stdioSetup);
+        await client.connect();
+        await client[Symbol.asyncDispose]();
+      });
+    });
+  });
+
+  describe("With Real Stdio Server", () => {
+    const stdioSetup: MCPSetupItem = {
+      name: "test-stdio",
+      type: "stdio",
+      command: "bun",
+      args: [
+        "run",
+        join(
+          process.cwd(),
+          "src/mcp/__test__/fixtures",
+          "test-stdio-server.js",
+        ),
+      ],
+    };
+
+    test("should connect to real server", async () => {
+      const client = new MCPClient(stdioSetup);
+      await client.connect();
+      await client[Symbol.asyncDispose]();
+    });
+
+    test("should call tool on real server", async () => {
+      const client = new MCPClient(stdioSetup);
+      await client.connect();
+
+      const result = await client.callTool("test-tool", { arg: "test-value" });
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe("text");
+      expect(result[0].text).toBe("Received arg: test-value");
+
+      await client[Symbol.asyncDispose]();
+    });
+
+    test("should read resource from real server", async () => {
+      const client = new MCPClient(stdioSetup);
+      await client.connect();
+
+      const result = await client.readResource("test://resource");
+      expect(result).toHaveLength(1);
+      expect(result[0].uri).toBe("test://resource");
+      expect(result[0].text).toBe("Test resource content");
+
+      await client[Symbol.asyncDispose]();
+    });
+  });
+});

--- a/src/mcp/__test__/fixtures/test-stdio-server.js
+++ b/src/mcp/__test__/fixtures/test-stdio-server.js
@@ -1,0 +1,37 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+const server = new McpServer({
+  name: "test-stdio-server",
+  version: "1.0.0",
+});
+
+server.tool(
+  "test-tool",
+  {
+    arg: z.string(),
+  },
+  async (args) => ({
+    content: [
+      {
+        type: "text",
+        text: `Received arg: ${args.arg}`,
+        mimeType: "text/plain",
+      },
+    ],
+  }),
+);
+
+server.resource("test-resource", "test://resource", async () => ({
+  contents: [
+    {
+      uri: "test://resource",
+      text: "Test resource content",
+      mimeType: "text/plain",
+    },
+  ],
+}));
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/src/mcp/client-manager.ts
+++ b/src/mcp/client-manager.ts
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+import { MCPClient, mcpItemSchema, MCPSetupItem } from "./client";
+
+export class MCPClientManager implements AsyncDisposable {
+  private items: MCPSetupItem[];
+  private clients: MCPClient[];
+
+  constructor(setupFilePath: string) {
+    if (!fs.existsSync(setupFilePath)) {
+      throw new Error(`MCP setup file not found: ${setupFilePath}`);
+    }
+    const setupContent = fs.readFileSync(setupFilePath, "utf-8");
+    let mcpSchemaObject: object;
+    try {
+      mcpSchemaObject = JSON.parse(setupContent);
+      if (!Array.isArray(mcpSchemaObject)) {
+        throw new Error(`MCP setup file must be array: ${setupFilePath}.`);
+      }
+    } catch (error) {
+      throw new Error(`Invalid MCP setup file: ${setupFilePath}`);
+    }
+    this.items = [];
+    this.clients = [];
+    for (const item of mcpSchemaObject) {
+      try {
+        const parsedItem = mcpItemSchema.parse(item);
+        this.items.push(parsedItem);
+      } catch (error) {
+        throw new Error(
+          `Invald MCP setup file: ${setupFilePath}\n${JSON.stringify(
+            item,
+          )}\n${error}`,
+          { cause: error },
+        );
+      }
+    }
+  }
+
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.stop();
+  }
+
+  async start(): Promise<void> {
+    this.clients = [];
+    for (const item of this.items) {
+      const client = new MCPClient(item);
+      await client.connect();
+      this.clients.push(client);
+    }
+  }
+
+  async stop(): Promise<void> {
+    for (const client of this.clients) {
+      try {
+        await client[Symbol.asyncDispose]();
+      } catch (error) {
+        console.error(`Error disposing client: ${error}`);
+      }
+    }
+  }
+
+  /**
+   * this function must be called after start()
+   */
+  getInstructionPrompt(): string {
+    return this.clients.map((c) => c.getInstructionPrompt()).join("\n");
+  }
+
+  getClient(serverName: string): MCPClient | null {
+    return this.clients.find((c) => c.name === serverName) ?? null;
+  }
+}

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,0 +1,165 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { Transport } from "@modelcontextprotocol/sdk/shared/transport";
+import { Resource, Tool } from "@modelcontextprotocol/sdk/types";
+import { z } from "zod";
+
+export const mcpItemSchema = z.discriminatedUnion("type", [
+  z.object({
+    name: z.string(),
+    type: z.literal("stdio"),
+    command: z.string(),
+    args: z.array(z.string()),
+  }),
+  z.object({
+    name: z.string(),
+    type: z.literal("sse"),
+    url: z.string(),
+  }),
+]);
+
+export type MCPSetupItem = z.infer<typeof mcpItemSchema>;
+export type MCPResource = {
+  uri: string;
+  mimeType?: string;
+  blob?: Blob;
+  text?: string;
+};
+export type MCPToolResult = {
+  type: "text" | "image" | "resource";
+  text?: string;
+  data?: string;
+  mimeType?: string;
+};
+
+function createToolPrompt(tool: Tool): string {
+  return `<mcp_tool>
+<name>${tool.name}</name>
+<description>${tool.description}</description>
+<json_schema>
+${JSON.stringify(tool.inputSchema, null, 2)}
+</json_schema>
+</mcp_tool>`;
+}
+
+function createResourcePrompt(resource: Resource): string {
+  return `<mcp_resource>
+<name>${resource.name}</name>
+<uri>${resource.uri}</uri>
+<description>${resource.description}</description>
+<mime_type>${resource.mimeType}</mime_type>
+</mcp_resource>`;
+}
+
+export class MCPClient implements AsyncDisposable {
+  private item: MCPSetupItem;
+  private client: Client;
+  private transport: Transport;
+  private tools: Tool[];
+  private resources: Resource[];
+
+  constructor(item: MCPSetupItem) {
+    this.item = item;
+    this.tools = [];
+    this.resources = [];
+    this.client = new Client({
+      name: this.item.name,
+      version: "1.0.0",
+    });
+    this.transport = this.createTransport();
+  }
+
+  get name(): string {
+    return this.item.name;
+  }
+
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.transport.close();
+    await this.client.close();
+  }
+
+  public async connect() {
+    await this.client.connect(this.transport);
+    await this.gatherServerInfo();
+  }
+
+  private createTransport(): Transport {
+    if (this.item.type === "stdio") {
+      return new StdioClientTransport({
+        command: this.item.command,
+        args: this.item.args,
+      });
+    }
+    if (this.item.type === "sse") {
+      return new SSEClientTransport(new URL(this.item.url));
+    }
+    throw new Error(`Invalid MCP setup item: ${JSON.stringify(this.item)}`);
+  }
+
+  private async gatherServerInfo(): Promise<void> {
+    const capabilities = await this.client.getServerCapabilities();
+    if (!capabilities) {
+      return;
+    }
+    if (capabilities.tools) {
+      const t = await this.client.listTools();
+      this.tools.push(...t.tools);
+    }
+    if (capabilities.resources) {
+      const r = await this.client.listResources();
+      this.resources.push(...r.resources);
+    }
+  }
+
+  public getInstructionPrompt(): string {
+    return `
+<mcp_server>
+<name>${this.item.name}</name>
+${this.tools.map((t) => createToolPrompt(t)).join("\n")}
+${this.resources.map((r) => createResourcePrompt(r)).join("\n")}
+</mcp_server>
+`;
+  }
+
+  public async callTool(
+    name: string,
+    args: Record<string, any>,
+  ): Promise<MCPToolResult[]> {
+    const result = await this.client.callTool({
+      name,
+      arguments: args,
+    });
+    if (!result || !result.content) {
+      throw new Error(`Tool call failed: ${name}`);
+    }
+    if (!Array.isArray(result.content)) {
+      throw new Error(`Tool call result is not an array: ${name}`);
+    }
+    return result.content.map((c) => {
+      return {
+        type: c.type,
+        text: c.text,
+        data: c.data,
+        mimeType: c.mimeType,
+      };
+    });
+  }
+
+  public async readResource(uri: string): Promise<MCPResource[]> {
+    const r = await this.client.readResource({
+      uri,
+    });
+    if (!r) {
+      throw new Error(`Resource not found: ${uri}`);
+    }
+    return r.contents.map((c) => {
+      return {
+        uri: c.uri,
+        mimeType: c.mimeType,
+        blob: c.blob as Blob,
+        text: c.text as string,
+      };
+    });
+  }
+}


### PR DESCRIPTION
<!-- AICA GENERATED -->
## Summary

| Category | Description |
|---|---|
| enhance | Added 'mcp.json' to .gitignore so that MCP configuration files are ignored. |
| docs | Updated aica.example.toml by adding a new [mcp] section with comments and example configuration for MCP servers. |
| enhance | Updated bun.lock and package.json to include new dependencies (e.g., @modelcontextprotocol/sdk and related packages) and removed the 'postinstall' script. |
| refactor | Refactored actions/edit.ts and agent-command.ts to instantiate Agent using the async disposable pattern ('await using agent = new Agent(...)'). |
| enhance | Refactored the Agent class to implement AsyncDisposable, integrate MCP client management (conditionally initializing MCPClientManager using config.mcp.setupFile), handle start/stop lifecycle, and include MCP instructions in the system prompt. |
| enhance | Updated getSystemPrompt in system-prompt.ts to accept an additional mcpPrompt parameter and include MCP information in the final system prompt. |
| refactor | Modified the Tool interface and all tool implementations to accept a ToolExecutionContext (including the MCP client manager) instead of only parameters, enabling MCP integration. |
| feature | Introduced new MCP tool functionalities by adding UseMcpTool and UseMcpResource classes, allowing invocation of MCP server tools and resource retrieval. |
| enhance | Updated configuration (in config.ts) to include a new 'mcp' property with a setupFile path, enabling MCP configuration. |
| feature | Added new MCP client code and tests: new files for MCPClientManager and MCPClient to handle connections, client creation, and disposal, along with test cases and a test server fixture. |