### PR TITLE
chore: add biome and lefthook for code formatting and linting

### DIFF
--- a/.github/workflows/autoreview.yaml
+++ b/.github/workflows/autoreview.yaml
@@ -23,4 +23,6 @@ jobs:
         uses: dotneet/aica@v0.0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          AICA_LLM_PROVIDER: anthropic
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/autoreview.yaml
+++ b/.github/workflows/autoreview.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: AI Code Analyzer
-        uses: dotneet/aica@v0.0.5
+        uses: dotneet/aica@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AICA_LLM_PROVIDER: anthropic

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": false,
+    "clientKind": "git",
+    "useIgnoreFile": false
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "ignore": ["tmp"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double"
+    }
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -21,9 +21,11 @@
         "zod": "^3.24.2",
       },
       "devDependencies": {
+        "@biomejs/biome": "1.9.4",
         "@types/bun": "latest",
         "@types/glob": "^8.1.0",
         "@types/yargs": "^17.0.33",
+        "lefthook": "^1.11.0",
       },
       "peerDependencies": {
         "typescript": "^5.7.3",
@@ -48,6 +50,24 @@
     "@babel/parser": ["@babel/parser@7.26.8", "", { "dependencies": { "@babel/types": "^7.26.8" }, "bin": "./bin/babel-parser.js" }, "sha512-TZIQ25pkSoaKEYYaHbbxkfL36GNsQ6iFiBbeuzAkLnXayKR1yP1zFe+NxuZWWsUyvt8icPU9CCq0sgWGXR1GEw=="],
 
     "@babel/types": ["@babel/types@7.26.8", "", { "dependencies": { "@babel/helper-string-parser": "^7.25.9", "@babel/helper-validator-identifier": "^7.25.9" } }, "sha512-eUuWapzEGWFEpHFxgEaBG8e3n6S8L3MSu0oda755rOfabWPnh0Our1AozNFVUxGFIhbKgd1ksprsoDGMinTOTA=="],
+
+    "@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@1.9.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@1.9.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@1.9.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
 
     "@colors/colors": ["@colors/colors@1.6.0", "", {}, "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="],
 
@@ -103,7 +123,7 @@
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@2.3.0", "", {}, "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg=="],
 
-    "@types/bun": ["@types/bun@1.2.2", "", { "dependencies": { "bun-types": "1.2.2" } }, "sha512-tr74gdku+AEDN5ergNiBnplr7hpDp3V1h7fqI2GcR/rsUaM39jpSeKH0TFibRvU0KwniRx5POgaYnaXbk0hU+w=="],
+    "@types/bun": ["@types/bun@1.2.3", "", { "dependencies": { "bun-types": "1.2.3" } }, "sha512-054h79ipETRfjtsCW9qJK8Ipof67Pw9bodFWmkfkaUaRiIQ1dIV2VTlheshlBx3mpKr0KeK8VqnMMCtgN9rQtw=="],
 
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
@@ -181,7 +201,7 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "bun-types": ["bun-types@1.2.2", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-RCbMH5elr9gjgDGDhkTTugA21XtJAy/9jkKe/G3WR2q17VPGhcquf9Sir6uay9iW+7P/BV0CAHA1XlHXMAVKHg=="],
+    "bun-types": ["bun-types@1.2.3", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-P7AeyTseLKAvgaZqQrvp3RqFM3yN9PlcLuSTe7SoJOfZkER73mLdT2vEQi8U64S1YvM/ldcNiQjn0Sn7H9lGgg=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -376,6 +396,28 @@
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "kuler": ["kuler@2.0.0", "", {}, "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="],
+
+    "lefthook": ["lefthook@1.11.0", "", { "optionalDependencies": { "lefthook-darwin-arm64": "1.11.0", "lefthook-darwin-x64": "1.11.0", "lefthook-freebsd-arm64": "1.11.0", "lefthook-freebsd-x64": "1.11.0", "lefthook-linux-arm64": "1.11.0", "lefthook-linux-x64": "1.11.0", "lefthook-openbsd-arm64": "1.11.0", "lefthook-openbsd-x64": "1.11.0", "lefthook-windows-arm64": "1.11.0", "lefthook-windows-x64": "1.11.0" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-FSNRtrcFIe0FUxqEs/0ZYyY7yUvAXLrY8Fic1CRagcSpcC7MByjAV2utkTaslGo4+GPLaZnZL4JD1lNdN/8r2A=="],
+
+    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@1.11.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-1Man6kmkFIB6Kn0vjrnPaBvIena3cZp/BjN58mCV3ErS5OjYDWtuUe2bl+y1uYDoNzOjiQQvdGWplroYD7Lslw=="],
+
+    "lefthook-darwin-x64": ["lefthook-darwin-x64@1.11.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-rQ7JJlLjaJNEk/mw7hp2/yGSdsmD2ZcQoH3slSQKfNaMjpZX3HXyBjZODUWtWqx7XqHqgU/SURMNmh/neBirdA=="],
+
+    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@1.11.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-4FzuYhwtVdekslo6sa3p8ZR2q2qsFtwaNPCUXoisre1aKdL0k8QNQlk0fCZ20/WK7lu+N21CUOKP3LI8iY1dHQ=="],
+
+    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@1.11.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-26bOviVrePVJ9pOTFsJgRaS1ZigbTPj3OZFbMlLT+0Cu54uFKZWe5BNg1AZ2y4ioNrg16pilWZYNyc5wL0DlIg=="],
+
+    "lefthook-linux-arm64": ["lefthook-linux-arm64@1.11.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-iNfa92n4M9EGMKGC8j3l6nlAjX8o7KnuHMA1pWudiSnPwfJwJozNcZH/jhe+A0eqYLkvZ18OlAmJfXFrVBQ0Lg=="],
+
+    "lefthook-linux-x64": ["lefthook-linux-x64@1.11.0", "", { "os": "linux", "cpu": "x64" }, "sha512-2NtenHWnPbv27CufQwxVj6HaHqvZmP4qfFwgt+yMmghLml9WLmY3fHjw+CDhAKvlKsBv1mPuE+sGVEhnz7R0zA=="],
+
+    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@1.11.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-j4kxeWUWDcofJHZs4yF0JnoRRuE92xekxh2i22mdufVmCBNOSiWGOT78hT5UwfQucjVjKY3oCtGH29ItiY0J1g=="],
+
+    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@1.11.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-QaTbLaDpdSjHLsNronxYqrEVEMV2+wRnF8kvffAiWIoMl1Z15acxHNrGtXNywZ4OhsKifqt6w+CLQyoZfm7u7g=="],
+
+    "lefthook-windows-arm64": ["lefthook-windows-arm64@1.11.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-dxtQ+JCOaHJBuC+I4y0ati0cT62vui2WUlhc4AS/UPv3kp/UZC8ahdnYPAlg3xVLmAgb0nBOyHm7pYVq3A62MQ=="],
+
+    "lefthook-windows-x64": ["lefthook-windows-x64@1.11.0", "", { "os": "win32", "cpu": "x64" }, "sha512-7ca/WQS3TYBwL2puzTFHM8wj6zZGuRlZKYkzLQncJ3+9UjVL+kcT9PuL4kOMs7sXyCsAYsdhNuko70w/28nTRA=="],
 
     "lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,11 @@
+pre-commit:
+  commands:
+    check:
+      glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+      run: bun run check
+
+pre-push:
+  commands:
+    check:
+      glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+      run: bun run check

--- a/package.json
+++ b/package.json
@@ -9,12 +9,17 @@
   "scripts": {
     "start": "bun run src/main.ts",
     "build": "bun build --compile --outfile dist/aica src/main.ts",
-    "build:actions": "bun build --compile --outfile dist/actions-runner src/actions-runner.ts"
+    "build:actions": "bun build --compile --outfile dist/actions-runner src/actions-runner.ts",
+    "lint": "biome check .",
+    "check": "biome check --write src",
+    "check:unsafe": "biome check --fix --unsafe src"
   },
   "devDependencies": {
+    "@biomejs/biome": "1.9.4",
     "@types/bun": "latest",
     "@types/glob": "^8.1.0",
-    "@types/yargs": "^17.0.33"
+    "@types/yargs": "^17.0.33",
+    "lefthook": "^1.11.0"
   },
   "peerDependencies": {
     "typescript": "^5.7.3"

--- a/src/actions-runner.ts
+++ b/src/actions-runner.ts
@@ -1,12 +1,12 @@
 import { readConfig } from "@/config";
 import core from "@actions/core";
 import github from "@actions/github";
-import { Octokit } from "./github";
-import { performSummaryAndReview } from "./actions/summary-and-review";
-import { performEdit } from "./actions/edit";
-import { performSummary } from "./actions/summary";
-import { performReviewCommand } from "./actions/review";
 import { $ } from "bun";
+import { performEdit } from "./actions/edit";
+import { performReviewCommand } from "./actions/review";
+import { performSummary } from "./actions/summary";
+import { performSummaryAndReview } from "./actions/summary-and-review";
+import { Octokit } from "./github";
 
 async function main() {
   console.log("start actions runner...");
@@ -16,7 +16,7 @@ async function main() {
       throw new Error("GITHUB_TOKEN is required");
     }
 
-    if (Bun.env.GITHUB_ACTIONS == "true" && Bun.env.GITHUB_WORKSPACE) {
+    if (Bun.env.GITHUB_ACTIONS === "true" && Bun.env.GITHUB_WORKSPACE) {
       // avoid the following error
       //fatal: detected dubious ownership in repository at '/github/workspace'
       await $`git config --global --add safe.directory ${Bun.env.GITHUB_WORKSPACE}`;
@@ -122,10 +122,12 @@ function extractCommands(body: string): AicaActionsCommand[] {
   for (const line of lines) {
     if (line.startsWith(prefix)) {
       const args = line.slice(prefix.length).trim().split(" ");
-      commands.push({
-        command: args.shift()!,
-        args,
-      });
+      const command = args.shift() || "";
+      if (command) {
+        commands.push({ command, args });
+      } else {
+        throw new Error("command is required");
+      }
     }
   }
   return commands;

--- a/src/actions/edit.ts
+++ b/src/actions/edit.ts
@@ -1,7 +1,7 @@
 import { Agent } from "@/agent/agent";
-import { Config } from "@/config";
+import type { Config } from "@/config";
 import { GitRepository } from "@/git";
-import { Octokit } from "@/github";
+import type { Octokit } from "@/github";
 import { createLLM } from "@/llm/factory";
 import { $ } from "bun";
 

--- a/src/actions/review.ts
+++ b/src/actions/review.ts
@@ -1,5 +1,5 @@
-import { Config } from "@/config";
-import { Octokit, PullRequest } from "@/github";
+import type { Config } from "@/config";
+import { type Octokit, PullRequest } from "@/github";
 import { generateReview } from "@/github/mod";
 
 export async function performReviewCommand(
@@ -7,12 +7,12 @@ export async function performReviewCommand(
   octokit: Octokit,
   owner: string,
   repo: string,
-  pullNumber: number
+  pullNumber: number,
 ): Promise<void> {
   console.log("Generating review...");
   const pullRequest = new PullRequest(octokit, owner, repo, pullNumber);
   const diffString = await pullRequest.getDiff(pullNumber);
   const reviewResultTable = await generateReview(config, diffString);
-  const comment = "## Bug Report\n\n" + reviewResultTable;
+  const comment = `## Bug Report\n\n${reviewResultTable}`;
   await pullRequest.postComment(comment);
 }

--- a/src/actions/summary-and-review.ts
+++ b/src/actions/summary-and-review.ts
@@ -1,7 +1,7 @@
-import { Config } from "@/config";
+import type { Config } from "@/config";
 import { PullRequest } from "@/github";
+import type { Octokit } from "@/github";
 import { generateReview, generateSummary } from "@/github/mod";
-import { Octokit } from "@/github";
 
 function buildSummaryBody(body: string, summary: string): string {
   const summaryPrefix = "<!-- AICA GENERATED -->\n## Summary";
@@ -9,12 +9,12 @@ function buildSummaryBody(body: string, summary: string): string {
   if (body) {
     const index = body.indexOf(summaryPrefix);
     if (index !== -1) {
-      newBody = body.slice(0, index) + summaryPrefix + "\n\n" + summary;
+      newBody = `${body.slice(0, index) + summaryPrefix}\n\n${summary}`;
     } else {
-      newBody = body + "\n\n" + summaryPrefix + "\n\n" + summary;
+      newBody = `${body}\n\n${summaryPrefix}\n\n${summary}`;
     }
   } else {
-    newBody = summaryPrefix + "\n\n" + summary;
+    newBody = `${summaryPrefix}\n\n${summary}`;
   }
   return newBody;
 }
@@ -24,7 +24,7 @@ export async function performSummaryAndReview(
   octokit: Octokit,
   owner: string,
   repo: string,
-  pull_number: number
+  pull_number: number,
 ): Promise<void> {
   console.log("retrieve pull request diff...");
   const pullRequest = new PullRequest(octokit, owner, repo, pull_number);
@@ -42,6 +42,6 @@ export async function performSummaryAndReview(
   const reviewResultTable = await generateReview(config, diffString);
 
   console.log("post comment to pull request...");
-  const comment = "## Bug Report\n\n" + reviewResultTable;
+  const comment = `## Bug Report\n\n${reviewResultTable}`;
   await pullRequest.postComment(comment);
 }

--- a/src/actions/summary.ts
+++ b/src/actions/summary.ts
@@ -1,5 +1,5 @@
-import { Config } from "@/config";
-import { Octokit, PullRequest } from "@/github";
+import type { Config } from "@/config";
+import { type Octokit, PullRequest } from "@/github";
 import { generateSummary } from "@/github/mod";
 
 function buildSummaryBody(body: string, summary: string): string {
@@ -9,12 +9,12 @@ function buildSummaryBody(body: string, summary: string): string {
   if (body) {
     const index = body.indexOf(summaryPrefix);
     if (index !== -1) {
-      newBody = body.slice(0, index) + summaryPrefix + "\n\n" + summary;
+      newBody = `${body.slice(0, index) + summaryPrefix}\n\n${summary}`;
     } else {
-      newBody = body + "\n\n" + summaryPrefix + "\n\n" + summary;
+      newBody = `${body}\n\n${summaryPrefix}\n\n${summary}`;
     }
   } else {
-    newBody = summaryPrefix + "\n\n" + summary;
+    newBody = `${summaryPrefix}\n\n${summary}`;
   }
   newBody += `\n\nsummary updated at: ${createdAt}`;
   return newBody;
@@ -25,7 +25,7 @@ export async function performSummary(
   octokit: Octokit,
   owner: string,
   repo: string,
-  pullNumber: number
+  pullNumber: number,
 ): Promise<void> {
   console.log("Generating summary...");
   const pullRequest = new PullRequest(octokit, owner, repo, pullNumber);

--- a/src/agent/agent-history.ts
+++ b/src/agent/agent-history.ts
@@ -1,4 +1,4 @@
-import { ActionResult } from "./tool";
+import type { ActionResult } from "./tool";
 
 export type AgentHistoryItemType =
   | "user_prompt"

--- a/src/agent/agent.test.ts
+++ b/src/agent/agent.test.ts
@@ -1,17 +1,17 @@
-import { Config, RulesConfig } from "@/config";
-import { GitRepository } from "@/git";
-import { createLLM } from "@/llm/mod";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync, mkdirSync } from "node:fs";
+import { type Config, RulesConfig } from "@/config";
+import { GitRepository } from "@/git";
+import { createLLM } from "@/llm/mod";
 import { Agent } from "./agent";
-import { ActionBlock } from "./assistant-message";
+import type { ActionBlock } from "./assistant-message";
 import {
-  executeTool,
   createToolExecutionContext,
+  executeTool,
   initializeTools,
 } from "./tool/tool";
 
-function createTestConfig(stubResponse: string = ""): Config {
+function createTestConfig(stubResponse = ""): Config {
   return {
     workingDirectory: process.cwd(),
     llm: {

--- a/src/agent/assistant-message.test.ts
+++ b/src/agent/assistant-message.test.ts
@@ -1,8 +1,8 @@
-import { describe, test, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import {
+  type ActionBlock,
+  type PlainMessageBlock,
   parseAssistantMessage,
-  PlainMessageBlock,
-  ActionBlock,
 } from "./assistant-message";
 
 describe("parseAssistantMessage", () => {

--- a/src/agent/assistant-message.ts
+++ b/src/agent/assistant-message.ts
@@ -1,4 +1,4 @@
-import { ToolId, Action, validToolIds, isValidToolId } from "./tool/mod";
+import { type Action, ToolId, isValidToolId, validToolIds } from "./tool/mod";
 
 export type MessageBlock = PlainMessageBlock | ActionBlock;
 
@@ -44,18 +44,19 @@ export function parseAssistantMessage(message: string): MessageBlock[] {
   if (!message) {
     return [{ type: "plain", content: "" }];
   }
-  message = message.replace(/<thinking>\s?/g, "");
-  message = message.replace(/\s?<\/thinking>/g, "");
+  const processedMessage = message
+    .replace(/<thinking>\s?/g, "")
+    .replace(/\s?<\/thinking>/g, "");
 
   const blocks: MessageBlock[] = [];
   let currentIndex = 0;
 
-  while (currentIndex < message.length) {
-    const toolTagStart = message.indexOf("<", currentIndex);
+  while (currentIndex < processedMessage.length) {
+    const toolTagStart = processedMessage.indexOf("<", currentIndex);
 
     if (toolTagStart === -1) {
       // 残りのテキストをプレーンブロックとして追加
-      const remainingText = message.slice(currentIndex);
+      const remainingText = processedMessage.slice(currentIndex);
       if (remainingText) {
         blocks.push({ type: "plain", content: remainingText });
       }
@@ -66,12 +67,12 @@ export function parseAssistantMessage(message: string): MessageBlock[] {
     if (toolTagStart > currentIndex) {
       blocks.push({
         type: "plain",
-        content: message.slice(currentIndex, toolTagStart),
+        content: processedMessage.slice(currentIndex, toolTagStart),
       });
     }
 
     // ツールタグを探す
-    const potentialToolContent = message.slice(toolTagStart);
+    const potentialToolContent = processedMessage.slice(toolTagStart);
     const action = parseToolTag(potentialToolContent);
 
     if (action) {
@@ -86,7 +87,7 @@ export function parseAssistantMessage(message: string): MessageBlock[] {
       // 無効なタグの場合は、'<'をプレーンテキストとして扱う
       blocks.push({
         type: "plain",
-        content: message[toolTagStart],
+        content: processedMessage[toolTagStart],
       });
       currentIndex = toolTagStart + 1;
     }
@@ -114,5 +115,5 @@ export function parseAssistantMessage(message: string): MessageBlock[] {
 
   return mergedBlocks.length
     ? mergedBlocks
-    : [{ type: "plain", content: message }];
+    : [{ type: "plain", content: processedMessage }];
 }

--- a/src/agent/patch.test.ts
+++ b/src/agent/patch.test.ts
@@ -1,12 +1,13 @@
-import { expect, test, describe } from "bun:test";
-import { tmpdir } from "os";
-import { join } from "path";
+import { describe, expect, test } from "bun:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
-  createPatch,
-  checkPatchFormat,
+  type Patch,
   applyPatch,
-  parseHunk,
+  checkPatchFormat,
+  createPatch,
   createPatchFromDiff,
+  parseHunk,
 } from "./patch";
 
 describe("Patch functionality tests", () => {
@@ -60,7 +61,7 @@ describe("Patch functionality tests", () => {
         },
       ],
     };
-    expect(checkPatchFormat(invalidPatch as any)).toBe(false);
+    expect(checkPatchFormat(invalidPatch as unknown as Patch)).toBe(false);
   });
 
   test("applyPatch - applying unified format patch", () => {

--- a/src/agent/patch.ts
+++ b/src/agent/patch.ts
@@ -17,8 +17,8 @@ export function parseHunk(lines: string[], i: number): [PatchHunk, number] {
   // Handle single line format (@@ -1 +1 @@)
   const singleLineHeaderMatch = lines[i].match(/@@ -(\d+) \+(\d+) @@/);
   if (singleLineHeaderMatch) {
-    const oldStart = parseInt(singleLineHeaderMatch[1]);
-    const newStart = parseInt(singleLineHeaderMatch[2]);
+    const oldStart = Number.parseInt(singleLineHeaderMatch[1]);
+    const newStart = Number.parseInt(singleLineHeaderMatch[2]);
     const header = lines[i];
 
     const hunkLines: string[] = [];
@@ -59,10 +59,10 @@ export function parseHunk(lines: string[], i: number): [PatchHunk, number] {
     throw new Error(`Invalid hunk header: ${lines[i]}`);
   }
 
-  const oldStart = parseInt(headerMatch[1]);
-  const oldLines = parseInt(headerMatch[2]);
-  const newStart = parseInt(headerMatch[3]);
-  const newLines = parseInt(headerMatch[4]);
+  const oldStart = Number.parseInt(headerMatch[1]);
+  const oldLines = Number.parseInt(headerMatch[2]);
+  const newStart = Number.parseInt(headerMatch[3]);
+  const newLines = Number.parseInt(headerMatch[4]);
   const header = lines[i];
 
   const hunkLines: string[] = [];
@@ -213,7 +213,9 @@ export function createPatch(src: string, dst: string): Patch {
     const next = i + 1 < changes.length ? changes[i + 1] : null;
 
     // Calculate common lines between current and next change
-    const commonLines = next ? next.start - current.end : Infinity;
+    const commonLines = next
+      ? next.start - current.end
+      : Number.POSITIVE_INFINITY;
 
     // Only merge if there are no common lines (no shared context)
     if (next && commonLines === 0) {
@@ -239,7 +241,7 @@ export function createPatch(src: string, dst: string): Patch {
     } else {
       hunkStart = Math.max(0, change.start - context);
     }
-    let hunkEnd = Math.min(
+    const hunkEnd = Math.min(
       Math.max(srcLines.length, dstLines.length),
       change.end + context,
     );
@@ -249,24 +251,24 @@ export function createPatch(src: string, dst: string): Patch {
     // Add leading context
     for (let k = hunkStart; k < change.start; k++) {
       if (k < srcLines.length && k < dstLines.length) {
-        hunkLines.push(" " + srcLines[k]);
+        hunkLines.push(` ${srcLines[k]}`);
       }
     }
 
     // Add changed lines
     for (let k = change.start; k < change.end; k++) {
       if (k < srcLines.length) {
-        hunkLines.push("-" + srcLines[k]);
+        hunkLines.push(`-${srcLines[k]}`);
       }
       if (k < dstLines.length) {
-        hunkLines.push("+" + dstLines[k]);
+        hunkLines.push(`+${dstLines[k]}`);
       }
     }
 
     // Add trailing context
     for (let k = change.end; k < hunkEnd; k++) {
       if (k < srcLines.length && k < dstLines.length) {
-        hunkLines.push(" " + srcLines[k]);
+        hunkLines.push(` ${srcLines[k]}`);
       }
     }
 

--- a/src/agent/prompt/system-prompt.ts
+++ b/src/agent/prompt/system-prompt.ts
@@ -1,7 +1,7 @@
-import { Config, RulesConfig } from "@/config";
+import { Config, type RulesConfig } from "@/config";
 import { RulesFinder } from "@/llmcontext/rules-finder";
 import { getSystemInfoSection } from "@/llmcontext/system-environment";
-import { Source } from "@/source";
+import type { Source } from "@/source";
 
 export async function getSystemPrompt(
   cwd: string,

--- a/src/agent/similarity-patch.test.ts
+++ b/src/agent/similarity-patch.test.ts
@@ -1,12 +1,12 @@
-import { describe, test, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import {
-  splitTextIntoLines,
+  applyPatchWithSimilarity,
+  computeSimilarity,
+  extractHunks,
+  findMostSimilarBlockIndex,
   joinLinesIntoText,
   parseUnifiedDiff,
-  extractHunks,
-  computeSimilarity,
-  findMostSimilarBlockIndex,
-  applyPatchWithSimilarity,
+  splitTextIntoLines,
 } from "./similarity-patch";
 
 /**
@@ -376,7 +376,7 @@ describe("similarity-patch3 テスト", () => {
       const diffText = [
         "@@ -1,3 +1,4 @@",
         " // 短い行",
-        " " + longString,
+        ` ${longString}`,
         "+// 新しく追加された行",
         " // 別の短い行",
       ].join("\n");

--- a/src/agent/similarity-patch.ts
+++ b/src/agent/similarity-patch.ts
@@ -202,7 +202,7 @@ export function applyPatchWithSimilarity(
 ): string {
   const originalLines = splitTextIntoLines(originalText);
   const unifiedDiff = parseUnifiedDiff(patchText);
-  let updatedLines = [...originalLines];
+  const updatedLines = [...originalLines];
 
   for (const hunk of unifiedDiff.hunks) {
     const segments = splitHunkIntoSegments(hunk);

--- a/src/agent/tool/tool.test.ts
+++ b/src/agent/tool/tool.test.ts
@@ -6,12 +6,17 @@ import {
   createRawPatch,
   createRawPatchFromString,
 } from "@/agent/patch";
-import { ToolError, executeTool, ToolExecutionContext } from "./tool";
+import {
+  ToolError,
+  type ToolExecutionContext,
+  type ToolId,
+  executeTool,
+} from "./tool";
 import { CreateFileTool } from "./tools/create-file";
 import { EditFileTool } from "./tools/edit-file";
+import { ExecuteCommandTool } from "./tools/execute-command";
 import { ListFilesTool } from "./tools/list-files";
 import { ReadFileTool } from "./tools/read-file";
-import { ExecuteCommandTool } from "./tools/execute-command";
 
 describe("Tools", () => {
   const testFilePath = "./tmp/test.ts";
@@ -212,7 +217,7 @@ describe("Tools", () => {
     it("should throw error for unknown tool", async () => {
       await expect(
         executeTool(context, tools, {
-          toolId: "unknown-tool" as any,
+          toolId: "unknown-tool" as ToolId,
           params: {},
         }),
       ).rejects.toThrow(ToolError);

--- a/src/agent/tool/tool.ts
+++ b/src/agent/tool/tool.ts
@@ -1,17 +1,17 @@
-import { Source } from "@/source";
+import type { MCPClientManager } from "@/mcp/client-manager";
+import type { Source } from "@/source";
 import {
+  AskFollowupQuestionTool,
+  AttemptCompletionTool,
   CreateFileTool,
   EditFileTool,
   ExecuteCommandTool,
   ListFilesTool,
   ReadFileTool,
   SearchFilesTool,
-  AttemptCompletionTool,
-  AskFollowupQuestionTool,
   diffToolPrompt,
 } from "./tools";
-import { UseMcpTool, UseMcpResource } from "./tools/mcp";
-import { MCPClientManager } from "@/mcp/client-manager";
+import { UseMcpResource, UseMcpTool } from "./tools/mcp";
 
 export type ToolId =
   | "create_file"

--- a/src/agent/tool/tools/ask-followup-question.ts
+++ b/src/agent/tool/tools/ask-followup-question.ts
@@ -1,9 +1,9 @@
 import {
-  Tool,
+  type Tool,
   ToolError,
-  ToolExecutionContext,
-  ToolExecutionResult,
-  ToolId,
+  type ToolExecutionContext,
+  type ToolExecutionResult,
+  type ToolId,
 } from "../tool";
 
 export class AskFollowupQuestionTool implements Tool {
@@ -49,7 +49,7 @@ export class AskFollowupQuestionTool implements Tool {
         if (line.trim() === "") {
           break;
         }
-        result += line + "\n";
+        result += `${line}\n`;
         process.stdout.write(prompt);
       }
       console.log("Thank you for your input.");
@@ -63,9 +63,8 @@ export class AskFollowupQuestionTool implements Tool {
         throw new ToolError(
           `Failed to ask followup question: ${error.message}`,
         );
-      } else {
-        throw new ToolError(`Failed to ask followup question: ${error}`);
       }
+      throw new ToolError(`Failed to ask followup question: ${error}`);
     }
   }
 }

--- a/src/agent/tool/tools/attempt-completion.ts
+++ b/src/agent/tool/tools/attempt-completion.ts
@@ -1,9 +1,9 @@
 import {
-  Tool,
+  type Tool,
   ToolError,
-  ToolExecutionContext,
-  ToolExecutionResult,
-  ToolId,
+  type ToolExecutionContext,
+  type ToolExecutionResult,
+  type ToolId,
 } from "../tool";
 
 export class AttemptCompletionTool implements Tool {
@@ -62,9 +62,8 @@ export class AttemptCompletionTool implements Tool {
       if (error instanceof ToolError) throw error;
       if (error instanceof Error) {
         throw new ToolError(`Failed to generate completion: ${error.message}`);
-      } else {
-        throw new ToolError(`Failed to generate completion: ${error}`);
       }
+      throw new ToolError(`Failed to generate completion: ${error}`);
     }
   }
 }

--- a/src/agent/tool/tools/create-file.ts
+++ b/src/agent/tool/tools/create-file.ts
@@ -1,10 +1,10 @@
 import { Source } from "@/source";
 import {
-  Tool,
+  type Tool,
   ToolError,
-  ToolExecutionContext,
-  ToolExecutionResult,
-  ToolId,
+  type ToolExecutionContext,
+  type ToolExecutionResult,
+  type ToolId,
 } from "../tool";
 
 export class CreateFileTool implements Tool {
@@ -47,9 +47,8 @@ export class CreateFileTool implements Tool {
       if (error instanceof ToolError) throw error;
       if (error instanceof Error) {
         throw new ToolError(`Failed to create file: ${error.message}`);
-      } else {
-        throw new ToolError(`Failed to create file: ${error}`);
       }
+      throw new ToolError(`Failed to create file: ${error}`);
     }
   }
 }

--- a/src/agent/tool/tools/edit-file.ts
+++ b/src/agent/tool/tools/edit-file.ts
@@ -1,18 +1,18 @@
-import { Source } from "@/source";
 import {
-  Tool,
-  ToolError,
-  ToolExecutionContext,
-  ToolExecutionResult,
-  ToolId,
-} from "../tool";
-import {
+  Patch,
   applyPatch,
   checkPatchFormat,
   createPatchFromDiff,
-  Patch,
 } from "@/agent/patch";
 import { applyPatchWithSimilarity } from "@/agent/similarity-patch";
+import { Source } from "@/source";
+import {
+  type Tool,
+  ToolError,
+  type ToolExecutionContext,
+  type ToolExecutionResult,
+  type ToolId,
+} from "../tool";
 
 export class EditFileTool implements Tool {
   name: ToolId = "edit_file";
@@ -57,9 +57,8 @@ export class EditFileTool implements Tool {
       if (error instanceof ToolError) throw error;
       if (error instanceof Error) {
         throw new ToolError(`Failed to edit file: ${error.message}`);
-      } else {
-        throw new ToolError(`Failed to edit file: ${error}`);
       }
+      throw new ToolError(`Failed to edit file: ${error}`);
     }
   }
 }

--- a/src/agent/tool/tools/execute-command.ts
+++ b/src/agent/tool/tools/execute-command.ts
@@ -1,9 +1,9 @@
 import {
-  Tool,
+  type Tool,
   ToolError,
-  ToolExecutionContext,
-  ToolExecutionResult,
-  ToolId,
+  type ToolExecutionContext,
+  type ToolExecutionResult,
+  type ToolId,
 } from "../tool";
 
 export class ExecuteCommandTool implements Tool {
@@ -59,9 +59,8 @@ export class ExecuteCommandTool implements Tool {
       if (error instanceof ToolError) throw error;
       if (error instanceof Error) {
         throw new ToolError(`Failed to execute command: ${error.message}`);
-      } else {
-        throw new ToolError(`Failed to execute command: ${error}`);
       }
+      throw new ToolError(`Failed to execute command: ${error}`);
     }
   }
 }

--- a/src/agent/tool/tools/list-files.ts
+++ b/src/agent/tool/tools/list-files.ts
@@ -1,11 +1,11 @@
+import { existsSync, mkdirSync, readdirSync } from "node:fs";
 import {
-  Tool,
+  type Tool,
   ToolError,
-  ToolExecutionContext,
-  ToolExecutionResult,
-  ToolId,
+  type ToolExecutionContext,
+  type ToolExecutionResult,
+  type ToolId,
 } from "../tool";
-import { readdirSync, mkdirSync, existsSync } from "node:fs";
 
 export class ListFilesTool implements Tool {
   name: ToolId = "list_files";
@@ -36,9 +36,8 @@ export class ListFilesTool implements Tool {
       if (error instanceof ToolError) throw error;
       if (error instanceof Error) {
         throw new ToolError(`Failed to list files: ${error.message}`);
-      } else {
-        throw new ToolError(`Failed to list files: ${error}`);
       }
+      throw new ToolError(`Failed to list files: ${error}`);
     }
   }
 }

--- a/src/agent/tool/tools/mcp.ts
+++ b/src/agent/tool/tools/mcp.ts
@@ -1,8 +1,8 @@
 import {
-  Tool,
+  type Tool,
   ToolError,
-  ToolExecutionContext,
-  ToolExecutionResult,
+  type ToolExecutionContext,
+  type ToolExecutionResult,
 } from "@/agent/tool/tool";
 
 export class UseMcpTool implements Tool {

--- a/src/agent/tool/tools/read-file.ts
+++ b/src/agent/tool/tools/read-file.ts
@@ -1,11 +1,11 @@
-import {
-  Tool,
-  ToolError,
-  ToolExecutionContext,
-  ToolExecutionResult,
-  ToolId,
-} from "../tool";
 import { Source } from "@/source";
+import {
+  type Tool,
+  ToolError,
+  type ToolExecutionContext,
+  type ToolExecutionResult,
+  type ToolId,
+} from "../tool";
 
 export class ReadFileTool implements Tool {
   name: ToolId = "read_file";
@@ -47,9 +47,8 @@ export class ReadFileTool implements Tool {
       if (error instanceof ToolError) throw error;
       if (error instanceof Error) {
         throw new ToolError(`Failed to read file: ${error.message}`);
-      } else {
-        throw new ToolError(`Failed to read file: ${error}`);
       }
+      throw new ToolError(`Failed to read file: ${error}`);
     }
   }
 }

--- a/src/agent/tool/tools/search-files.ts
+++ b/src/agent/tool/tools/search-files.ts
@@ -1,11 +1,11 @@
-import {
-  Tool,
-  ToolError,
-  ToolExecutionContext,
-  ToolExecutionResult,
-  ToolId,
-} from "../tool";
 import { globby } from "globby";
+import {
+  type Tool,
+  ToolError,
+  type ToolExecutionContext,
+  type ToolExecutionResult,
+  type ToolId,
+} from "../tool";
 
 export class SearchFilesTool implements Tool {
   name: ToolId = "search_files";
@@ -45,7 +45,7 @@ export class SearchFilesTool implements Tool {
       const pattern = args.filePattern || "**/*";
       const files = await globby(pattern, { cwd: args.path });
       const regExp = new RegExp(args.regex, "g");
-      let results: string[] = [];
+      const results: string[] = [];
 
       for (const file of files) {
         const fullPath = `${args.path}/${file}`;
@@ -85,9 +85,8 @@ export class SearchFilesTool implements Tool {
       if (error instanceof ToolError) throw error;
       if (error instanceof Error) {
         throw new ToolError(`Failed to search files: ${error.message}`);
-      } else {
-        throw new ToolError(`Failed to search files: ${error}`);
       }
+      throw new ToolError(`Failed to search files: ${error}`);
     }
   }
 }

--- a/src/commands/agent-command.ts
+++ b/src/commands/agent-command.ts
@@ -1,9 +1,9 @@
-import { z } from "zod";
-import { readConfig } from "@/config";
-import { Agent } from "@/agent/agent";
-import { createLLM } from "@/llm/mod";
-import { GitRepository } from "@/git";
 import * as readline from "node:readline";
+import { Agent } from "@/agent/agent";
+import { readConfig } from "@/config";
+import { GitRepository } from "@/git";
+import { createLLM } from "@/llm/mod";
+import { z } from "zod";
 
 export const agentCommandSchema = z.object({
   prompt: z.string().optional(),
@@ -12,7 +12,7 @@ export const agentCommandSchema = z.object({
 
 export type AgentCommandValues = z.infer<typeof agentCommandSchema>;
 
-export async function executeAgentCommand(params: any) {
+export async function executeAgentCommand(params: AgentCommandValues) {
   const values = agentCommandSchema.parse(params);
   let prompt = values.prompt || "";
   const config = await readConfig();
@@ -84,8 +84,11 @@ export async function executeAgentCommand(params: any) {
         console.log(
           "\nEnter your prompt (press Enter twice to submit, type 'exit' to end):",
         );
-      } catch (error: any) {
-        console.error("An error occurred:", error?.message || "Unknown error");
+      } catch (error: unknown) {
+        console.error(
+          "An error occurred:",
+          error instanceof Error ? error.message : "Unknown error",
+        );
         console.log(
           "\nEnter your prompt (press Enter twice to submit, type 'exit' to end):",
         );

--- a/src/commands/chat-command.ts
+++ b/src/commands/chat-command.ts
@@ -1,15 +1,15 @@
-import { z } from "zod";
-import { Config, readConfig } from "@/config";
-import { readFileSync } from "fs";
-import { createInterface } from "readline";
-import { LLM, Message } from "@/llm/mod";
-import { createLLM } from "@/llm/factory";
-import { RulesFinder } from "@/llmcontext/rules-finder";
+import { readFileSync } from "node:fs";
+import { createInterface } from "node:readline";
+import { type Config, readConfig } from "@/config";
 import { GitRepository } from "@/git";
+import { createLLM } from "@/llm/factory";
+import type { LLM, Message } from "@/llm/mod";
+import { RulesFinder } from "@/llmcontext/rules-finder";
 import {
   getEnvironmentDetailsPrompt,
   getSystemInfoSection,
 } from "@/llmcontext/system-environment";
+import { z } from "zod";
 
 export const chatCommandSchema = z.object({
   prompt: z.string().optional(),
@@ -59,7 +59,7 @@ async function handleInteractiveChat(llm: LLM, config: Config): Promise<void> {
     const response = await llm.generate(systemPrompt, messages, false);
     messages.push({ role: "assistant", content: response });
 
-    console.log("\n" + response + "\n");
+    console.log(`\n${response}\n`);
   }
 
   rl.close();

--- a/src/commands/commit-command.ts
+++ b/src/commands/commit-command.ts
@@ -1,4 +1,4 @@
-import { readConfig, type Config } from "@/config";
+import { type Config, readConfig } from "@/config";
 import { GitRepository } from "@/git";
 import { z } from "zod";
 import { createCommitMessageFromDiff } from "./commit-message-command";
@@ -95,7 +95,7 @@ export async function executeCommit(
 
   const commitMessage = await createCommitMessageFromDiff(config, diff);
   if (dryRun) {
-    console.log("DryRun: commit message is '" + commitMessage + "'");
+    console.log(`DryRun: commit message is '${commitMessage}'`);
   } else {
     await git.commit(commitMessage);
     console.log(`committed: ${commitMessage}`);

--- a/src/commands/commit-message-command.ts
+++ b/src/commands/commit-message-command.ts
@@ -1,5 +1,5 @@
 import { createAnalyzeContextFromConfig } from "@/analyze";
-import { readConfig, type Config } from "@/config";
+import { type Config, readConfig } from "@/config";
 import { GitRepository } from "@/git";
 import {
   getLanguageFromConfig,
@@ -44,8 +44,8 @@ export async function createCommitMessageFromDiff(
   const rules = config.commitMessage.prompt.rules
     .map((rule) => `- ${rule}`)
     .join("\n");
-  let language = getLanguageFromConfig(config);
-  let languagePrompt = getLanguagePromptForJson(language, ["commitMessage"]);
+  const language = getLanguageFromConfig(config);
+  const languagePrompt = getLanguagePromptForJson(language, ["commitMessage"]);
   const prompt = `
     ${config.commitMessage.prompt.user}
 

--- a/src/commands/create-pr-command.ts
+++ b/src/commands/create-pr-command.ts
@@ -1,12 +1,12 @@
-import { readConfig, type Config } from "@/config";
+import { type Config, readConfig } from "@/config";
 import { GitRepository } from "@/git";
-import { getGitHubToken, Octokit } from "@/github";
+import { Octokit, getGitHubToken } from "@/github";
+import { PullRequest } from "@/github";
+import { createBranchName } from "@/github/branch";
+import { generateSummary } from "@/github/summary";
 import { z } from "zod";
 import { executeCommit } from "./commit-command";
 import { createCommitMessageFromDiff } from "./commit-message-command";
-import { PullRequest } from "@/github";
-import { generateSummary } from "@/github/summary";
-import { createBranchName } from "@/github/branch";
 
 export const createPrCommandSchema = z.object({
   staged: z.boolean().default(false),

--- a/src/commands/review-command.ts
+++ b/src/commands/review-command.ts
@@ -1,13 +1,13 @@
+import process from "node:process";
 import {
-  Issue,
+  type Issue,
   analyzeCodeForBugs,
   createAnalyzeContextFromConfig,
   getCodesAroundIssue,
 } from "@/analyze";
-import process from "process";
 import { readConfig } from "@/config";
 import { sendToSlack } from "@/slack";
-import { Source, SourceFinder } from "@/source";
+import { type Source, SourceFinder } from "@/source";
 
 import { z } from "zod";
 

--- a/src/commands/show-config.ts
+++ b/src/commands/show-config.ts
@@ -1,5 +1,5 @@
-import { readConfig, defaultConfig } from "../config";
 import { z } from "zod";
+import { defaultConfig, readConfig } from "../config";
 
 export const showConfigValuesSchema = z.object({
   config: z.string().optional(),

--- a/src/commands/summary-diff-command.ts
+++ b/src/commands/summary-diff-command.ts
@@ -1,13 +1,13 @@
-import { readConfig, type Config } from "@/config";
+import { type Config, readConfig } from "@/config";
 import { GitRepository } from "@/git";
-import { z } from "zod";
+import { createLLM } from "@/llm/mod";
 import {
   type SummaryContext,
   type SummaryDiffItem,
-  summarizeDiff,
   createSummaryContext,
+  summarizeDiff,
 } from "@/summary";
-import { createLLM } from "@/llm/mod";
+import { z } from "zod";
 
 export const summaryDiffCommandSchema = z.object({
   dryRun: z.boolean().default(false),

--- a/src/embedding/factory.ts
+++ b/src/embedding/factory.ts
@@ -1,6 +1,6 @@
-import { EmbeddingConfig } from "@/config";
+import type { EmbeddingConfig } from "@/config";
 import {
-  EmbeddingProducer,
+  type EmbeddingProducer,
   EmbeddingProducerStub,
   OpenAIEmbeddingProducer,
 } from "./embedding";
@@ -11,9 +11,9 @@ export function createEmbeddingProducer(
   const { provider, openai } = settings;
   if (provider === "openai") {
     return new OpenAIEmbeddingProducer(openai.apiKey, openai.model);
-  } else if (provider === "stub") {
-    return new EmbeddingProducerStub();
-  } else {
-    throw new Error(`Unknown embedding provider: ${provider}`);
   }
+  if (provider === "stub") {
+    return new EmbeddingProducerStub();
+  }
+  throw new Error(`Unknown embedding provider: ${provider}`);
 }

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect } from "bun:test";
-import { GitRepository } from "./git";
-import { beforeEach, afterEach } from "bun:test";
+import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach } from "bun:test";
+import { execSync } from "node:child_process";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { execSync } from "node:child_process";
+import { GitRepository } from "./git";
 
 describe("GitRepository", () => {
   const testDir = join(process.cwd(), "test-repo");

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,10 +1,10 @@
-import { Issue } from "./analyze";
-import { SummaryDiffItem } from "./summary";
 import { Octokit as OctokitCore } from "@octokit/core";
 import {
+  type Api,
   restEndpointMethods,
-  Api,
 } from "@octokit/plugin-rest-endpoint-methods";
+import type { Issue } from "./analyze";
+import type { SummaryDiffItem } from "./summary";
 
 export const Octokit = OctokitCore.plugin(restEndpointMethods).defaults({});
 export type Octokit = InstanceType<typeof Octokit> & Api;
@@ -16,7 +16,7 @@ export function createGitHubStyleTableFromSummaryDiffItems(
   const table = summaryDiffItems.map((item) => {
     return `| ${item.category} | ${item.description} |`;
   });
-  return header + "\n" + "|---|---|" + "\n" + table.join("\n");
+  return `${header}\n|---|---|\n${table.join("\n")}`;
 }
 
 export function createGitHubStyleTableFromIssues(issues: Issue[]): string {
@@ -24,7 +24,7 @@ export function createGitHubStyleTableFromIssues(issues: Issue[]): string {
   const table = issues.map((issue) => {
     return `| ${issue.file} | ${issue.description} |`;
   });
-  return header + "\n" + "|---|---|" + "\n" + table.join("\n");
+  return `${header}\n|---|---|\n${table.join("\n")}`;
 }
 
 export class PullRequest {
@@ -67,7 +67,7 @@ export class PullRequest {
   }
 
   async getDiff(pullNumber: number): Promise<string> {
-    const endpoint = `GET /repos/{owner}/{repo}/pulls/{pull_number}`;
+    const endpoint = "GET /repos/{owner}/{repo}/pulls/{pull_number}";
     const response = await this.octokit.request(endpoint, {
       owner: this.owner,
       repo: this.repo,

--- a/src/github/branch.ts
+++ b/src/github/branch.ts
@@ -1,4 +1,4 @@
-import { Config } from "@/config";
+import type { Config } from "@/config";
 import { createLLM } from "@/llm/factory";
 
 export async function createBranchName(

--- a/src/github/review.test.ts
+++ b/src/github/review.test.ts
@@ -1,7 +1,7 @@
-import { generateReview } from "./review";
+import { describe, expect, it } from "bun:test";
 import { defaultConfig } from "@/config";
 import { deepAssign } from "@/utility/deep-assign";
-import { describe, it, expect } from "bun:test";
+import { generateReview } from "./review";
 
 // Mock diff string
 const mockDiffString =

--- a/src/github/review.ts
+++ b/src/github/review.ts
@@ -1,9 +1,9 @@
-import { Config } from "@/config";
 import {
-  Issue,
+  type Issue,
   analyzeCodeForBugs,
   createAnalyzeContextFromConfig,
 } from "@/analyze";
+import type { Config } from "@/config";
 import { Source } from "@/source";
 import { parseDiff } from "@/utility/parse-diff";
 import { createGitHubStyleTableFromIssues } from "../github";

--- a/src/github/summary.test.ts
+++ b/src/github/summary.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, it } from "bun:test";
+import { type Config, defaultConfig } from "@/config";
 import { generateSummary } from "./summary";
-import { Config, defaultConfig } from "@/config";
-import { describe, it, expect } from "bun:test";
 
 // テストケース
 describe("generateSummary", () => {

--- a/src/github/summary.ts
+++ b/src/github/summary.ts
@@ -1,8 +1,8 @@
-import { Config } from "@/config";
+import type { Config } from "@/config";
 import { createGitHubStyleTableFromSummaryDiffItems } from "@/github";
+import { getLanguageFromConfig } from "@/utility/language";
 import { createLLM } from "../llm/factory";
 import { createSummaryContext, summarizeDiff } from "../summary";
-import { getLanguageFromConfig } from "@/utility/language";
 
 export async function generateSummary(
   config: Config,

--- a/src/knowledge/extract-symbols.test.ts
+++ b/src/knowledge/extract-symbols.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import {
   extractDefinitionSymbols,
   extractReferenceSymbols,

--- a/src/knowledge/extract-symbols.ts
+++ b/src/knowledge/extract-symbols.ts
@@ -12,13 +12,13 @@ export function extractDefinitionSymbols(text: string) {
   ];
   const keywordLines = text
     .split("\n")
-    .filter((line) => keywords.some((keyword) => line.includes(keyword + " ")));
+    .filter((line) => keywords.some((keyword) => line.includes(`${keyword} `)));
 
   const symbols = keywordLines.map((line) => {
     return line
       .replace(
         /(export\s+)?(module|function|func|def|class|struct|type|interface)\s*([a-zA-Z0-9_]+).*/,
-        "$3"
+        "$3",
       )
       .trim();
   });
@@ -30,10 +30,9 @@ export function extractReferenceSymbols(text: string) {
   const keywords = ["import", "require", "use"];
   const keywordLines = text
     .split("\n")
-    .filter((line) => keywords.some((keyword) => line.includes(keyword + " ")));
-
+    .filter((line) => keywords.some((keyword) => line.includes(`${keyword} `)));
   const symbols: string[] = [];
-  keywordLines.forEach((line) => {
+  for (const line of keywordLines) {
     if (line.includes("import")) {
       const words = line
         .replace(/import\s+\{?\s*(\w+\s*(,\s*\w+)*)?\s*\}?/, "$1")
@@ -41,15 +40,14 @@ export function extractReferenceSymbols(text: string) {
         .split(",")
         .map((word) => word.trim());
       symbols.push(...words);
-      return;
-    } else {
-      const symbol = line
-        .replace(/(import|require|use) (\w+)/, "$2")
-        .replace(/({|}|=|;|"|'|,)/g, "")
-        .trim();
-      symbols.push(symbol);
+      continue;
     }
-  });
+    const symbol = line
+      .replace(/(import|require|use) (\w+)/, "$2")
+      .replace(/({|}|=|;|"|'|,)/g, "")
+      .trim();
+    symbols.push(symbol);
+  }
 
   return symbols;
 }

--- a/src/llm/anthropic.ts
+++ b/src/llm/anthropic.ts
@@ -1,13 +1,13 @@
-import { LLMConfigAnthropic } from "@/config";
+import type { LLMConfigAnthropic } from "@/config";
 import {
-  extractJsonFromText,
-  LLM,
-  Message,
-  withRetry,
-  LLMOptions,
+  type LLM,
+  type LLMOptions,
   LLMRateLimitError,
+  type Message,
+  extractJsonFromText,
+  withRetry,
 } from "./llm";
-import { createLLMLogger, LLMLogger } from "./logger";
+import { type LLMLogger, createLLMLogger } from "./logger";
 
 type ClaudeMessageResponse = {
   id: string;
@@ -85,7 +85,7 @@ export class LLMAnthropic implements LLM {
           const retryAfter = response.headers.get("Retry-After");
           throw new LLMRateLimitError(
             "Rate limit exceeded",
-            retryAfter ? parseInt(retryAfter) : undefined,
+            retryAfter ? Number.parseInt(retryAfter) : undefined,
           );
         }
         const errorData = await response
@@ -107,17 +107,14 @@ export class LLMAnthropic implements LLM {
       );
     }
 
-    let text = responseObject.content[0].text;
+    const text = responseObject.content[0].text;
     if (jsonMode) {
       const json = extractJsonFromText(text);
       if (json) {
         this.logger.log(`LLM Anthropic response: ${json}`);
         return json;
-      } else {
-        throw new Error(
-          "Invalid response from Anthropic API: No JSON received",
-        );
       }
+      throw new Error("Invalid response from Anthropic API: No JSON received");
     }
     this.logger.log(`LLM Anthropic response: ${text}`);
     return text;

--- a/src/llm/factory.test.ts
+++ b/src/llm/factory.test.ts
@@ -1,6 +1,6 @@
-import { describe, test, expect, beforeEach } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
+import { type LLMConfig, type LLMProvider, readConfig } from "@/config";
 import { createLLM } from "./factory";
-import { LLMConfig, readConfig } from "@/config";
 
 describe("LLM Factory", () => {
   let defaultConfig: LLMConfig;
@@ -178,7 +178,7 @@ describe("LLM Factory", () => {
   test("should throw error for unknown provider", async () => {
     const config = {
       ...defaultConfig,
-      provider: "unknown" as any,
+      provider: "unknown" as LLMProvider,
     };
     expect(() => createLLM(config)).toThrow("Unknown LLM provider: unknown");
   });

--- a/src/llm/factory.ts
+++ b/src/llm/factory.ts
@@ -1,7 +1,7 @@
-import { LLMConfig } from "@/config";
+import type { LLMConfig } from "@/config";
 import { LLMAnthropic } from "./anthropic";
 import { LLMGoogle } from "./google";
-import { LLM } from "./llm";
+import type { LLM } from "./llm";
 import { LLMOpenAI } from "./openai";
 import { LLMStub } from "./stub";
 
@@ -9,13 +9,15 @@ export function createLLM(settings: LLMConfig): LLM {
   const { provider, openai, anthropic, google } = settings;
   if (provider === "openai") {
     return new LLMOpenAI(openai);
-  } else if (provider === "anthropic") {
-    return new LLMAnthropic(anthropic);
-  } else if (provider === "google") {
-    return new LLMGoogle(google);
-  } else if (provider === "stub") {
-    return new LLMStub(settings.stub.response);
-  } else {
-    throw new Error(`Unknown LLM provider: ${provider}`);
   }
+  if (provider === "anthropic") {
+    return new LLMAnthropic(anthropic);
+  }
+  if (provider === "google") {
+    return new LLMGoogle(google);
+  }
+  if (provider === "stub") {
+    return new LLMStub(settings.stub.response);
+  }
+  throw new Error(`Unknown LLM provider: ${provider}`);
 }

--- a/src/llm/google.ts
+++ b/src/llm/google.ts
@@ -1,13 +1,13 @@
-import { LLMConfigGemini } from "@/config";
+import type { LLMConfigGemini } from "@/config";
 import {
-  LLM,
+  type LLM,
   LLMError,
-  Message,
-  withRetry,
-  LLMOptions,
+  type LLMOptions,
   LLMRateLimitError,
+  type Message,
+  withRetry,
 } from "./llm";
-import { createLLMLogger, LLMLogger } from "./logger";
+import { type LLMLogger, createLLMLogger } from "./logger";
 
 export class LLMGoogle implements LLM {
   private config: LLMConfigGemini;

--- a/src/llm/llm.test.ts
+++ b/src/llm/llm.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { extractJsonFromText } from "./llm";
 
 describe("extractJsonFrom", () => {

--- a/src/llm/llm.ts
+++ b/src/llm/llm.ts
@@ -26,7 +26,7 @@ export async function withRetry<T>(
       if (attempt === maxRetries) {
         throw error;
       }
-      let backoffDelay = retryDelay * Math.pow(2, attempt - 1);
+      let backoffDelay = retryDelay * 2 ** (attempt - 1);
       console.warn(
         `LLM attempt ${attempt} failed, retrying in ${backoffDelay}ms...`,
       );

--- a/src/llm/logger.ts
+++ b/src/llm/logger.ts
@@ -1,5 +1,5 @@
 import winston from "winston";
-import { Message } from "./llm";
+import type { Message } from "./llm";
 
 export interface LLMLogger {
   log(message: string): void;

--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -1,13 +1,13 @@
-import { LLMConfigOpenAI } from "@/config";
+import type { LLMConfigOpenAI } from "@/config";
 import {
-  LLM,
+  type LLM,
   LLMError,
-  Message,
-  withRetry,
-  LLMOptions,
+  type LLMOptions,
   LLMRateLimitError,
+  type Message,
+  withRetry,
 } from "./llm";
-import { createLLMLogger, LLMLogger } from "./logger";
+import { type LLMLogger, createLLMLogger } from "./logger";
 
 interface GPTResponse {
   choices: {

--- a/src/llm/stub.ts
+++ b/src/llm/stub.ts
@@ -1,4 +1,4 @@
-import { LLM, Message } from "./llm";
+import type { LLM, Message } from "./llm";
 
 export class LLMStub implements LLM {
   constructor(private response: string) {}

--- a/src/llmcontext/rules-finder.test.ts
+++ b/src/llmcontext/rules-finder.test.ts
@@ -1,8 +1,8 @@
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import fs from "node:fs";
 import path from "node:path";
+import type { RulesConfig } from "../config";
 import { RulesFinder } from "./rules-finder";
-import { RulesConfig } from "../config";
 
 describe("RulesFinder", () => {
   const testDir = ".test-rules-finder";

--- a/src/llmcontext/rules-finder.ts
+++ b/src/llmcontext/rules-finder.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { RulesConfig } from "../config";
+import type { RulesConfig } from "../config";
 
 export type MDCContent = {
   description: string;
@@ -151,7 +151,7 @@ export class RulesFinder {
 
         const fullPath = path.join(rulesDir, mdcFile);
         const content = await this.readMDCFile(fullPath);
-        if (content && content.globs) {
+        if (content?.globs) {
           const matches = await this.matchesGlobPattern(
             filePaths,
             content.globs,

--- a/src/llmcontext/system-environment.internal.test.ts
+++ b/src/llmcontext/system-environment.internal.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import {
   composeIgnorePatterns,
   matchGitignorePattern,

--- a/src/llmcontext/system-environment.test.ts
+++ b/src/llmcontext/system-environment.test.ts
@@ -1,7 +1,7 @@
-import { describe, test, expect, beforeAll, afterAll } from "bun:test";
-import { listFiles, ListFilesResult } from "./system-environment";
-import { mkdir, writeFile, rm } from "node:fs/promises";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { type ListFilesResult, listFiles } from "./system-environment";
 
 describe("listFiles", () => {
   const testDir = join(import.meta.dir, "test-files");
@@ -147,8 +147,8 @@ debug/**/debug.log
 
   test("should return absolute paths", () => {
     const result: ListFilesResult = listFiles(testDir, 10);
-    result.files.forEach((path) => {
+    for (const path of result.files) {
       expect(path.startsWith("/")).toBe(true);
-    });
+    }
   });
 });

--- a/src/llmcontext/system-environment.ts
+++ b/src/llmcontext/system-environment.ts
@@ -1,8 +1,8 @@
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import os from "node:os";
+import { join, relative } from "node:path";
 import { toPosixPath } from "@/utility/path";
-import { readdirSync, statSync, existsSync, readFileSync } from "fs";
-import os from "os";
 import osName from "os-name";
-import { join, relative } from "path";
 
 function getShellFromEnv(): string | null {
   const { env } = process;
@@ -25,7 +25,7 @@ function getShellFromEnv(): string | null {
 }
 
 export function getSystemInfoSection(cwd: string): string {
-  let details = `====
+  const details = `====
   
   SYSTEM INFORMATION
   

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,4 @@
-import yargs from "yargs";
-import { hideBin } from "yargs/helpers";
-import type { ArgumentsCamelCase, Argv } from "yargs";
+import { executeAgentCommand } from "@/commands/agent-command";
 import {
   commitMessageCommandSchema,
   executeCommitMessageCommand,
@@ -9,30 +7,32 @@ import {
   executeReviewCommand,
   reviewCommandSchema,
 } from "@/commands/review-command";
-import pkg from "../package.json";
 import {
   executeSummaryDiffCommand,
   summaryDiffCommandSchema,
 } from "@/commands/summary-diff-command";
-import {
-  createPrCommandSchema,
-  executeCreatePrCommand,
-} from "./commands/create-pr-command";
+import yargs from "yargs";
+import type { ArgumentsCamelCase, Argv } from "yargs";
+import { hideBin } from "yargs/helpers";
+import pkg from "../package.json";
+import { chatCommandSchema, executeChatCommand } from "./commands/chat-command";
 import {
   commitCommandSchema,
   executeCommitCommand,
 } from "./commands/commit-command";
-import { CommandError } from "./commands/error";
 import {
-  executeShowConfigCommand,
-  showConfigValuesSchema,
-} from "./commands/show-config";
+  createPrCommandSchema,
+  executeCreatePrCommand,
+} from "./commands/create-pr-command";
+import { CommandError } from "./commands/error";
 import {
   executeIndexCommand as executeReindexCommand,
   indexCommandSchema,
 } from "./commands/index-command";
-import { executeChatCommand, chatCommandSchema } from "./commands/chat-command";
-import { executeAgentCommand } from "@/commands/agent-command";
+import {
+  executeShowConfigCommand,
+  showConfigValuesSchema,
+} from "./commands/show-config";
 
 async function main() {
   const argv = await yargs(hideBin(process.argv))

--- a/src/mcp/__test__/client.test.ts
+++ b/src/mcp/__test__/client.test.ts
@@ -1,6 +1,6 @@
-import { describe, test, expect, beforeEach, mock } from "bun:test";
-import { MCPClient, MCPSetupItem } from "../client";
-import { join } from "path";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { join } from "node:path";
+import { MCPClient, type MCPSetupItem } from "../client";
 
 // モックの実装
 const mockTransport = {
@@ -47,7 +47,7 @@ describe("MCPClient", () => {
       mock.module("@modelcontextprotocol/sdk/client/sse.js", () => ({
         SSEClientTransport: class {
           constructor() {
-            return mockTransport;
+            Object.assign(this, mockTransport);
           }
         },
       }));
@@ -55,7 +55,7 @@ describe("MCPClient", () => {
       mock.module("@modelcontextprotocol/sdk/client/stdio.js", () => ({
         StdioClientTransport: class {
           constructor() {
-            return mockTransport;
+            Object.assign(this, mockTransport);
           }
         },
       }));
@@ -64,7 +64,7 @@ describe("MCPClient", () => {
       mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
         Client: class {
           constructor() {
-            return mockClientImplementation;
+            Object.assign(this, mockClientImplementation);
           }
         },
       }));

--- a/src/mcp/client-manager.ts
+++ b/src/mcp/client-manager.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { MCPClient, mcpItemSchema, MCPSetupItem } from "./client";
+import { MCPClient, type MCPSetupItem, mcpItemSchema } from "./client";
 
 export class MCPClientManager implements AsyncDisposable {
   private items: MCPSetupItem[];

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,8 +1,8 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { Transport } from "@modelcontextprotocol/sdk/shared/transport";
-import { Resource, Tool } from "@modelcontextprotocol/sdk/types";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport";
+import type { Resource, Tool } from "@modelcontextprotocol/sdk/types";
 import { z } from "zod";
 
 export const mcpItemSchema = z.discriminatedUnion("type", [
@@ -124,7 +124,7 @@ ${this.resources.map((r) => createResourcePrompt(r)).join("\n")}
 
   public async callTool(
     name: string,
-    args: Record<string, any>,
+    args: Record<string, unknown>,
   ): Promise<MCPToolResult[]> {
     const result = await this.client.callTool({
       name,

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -1,4 +1,6 @@
-export async function sendToSlack(file: string, bugs: any[]): Promise<void> {
+import type { Issue } from "./analyze";
+
+export async function sendToSlack(file: string, bugs: Issue[]): Promise<void> {
   if (!Bun.env.SLACK_BOT_TOKEN || !Bun.env.SLACK_CHANNEL_ID) {
     console.error("SLACK_BOT_TOKEN or SLACK_CHANNEL_ID is not set.");
     return;

--- a/src/source.test.ts
+++ b/src/source.test.ts
@@ -1,11 +1,11 @@
+import { describe, expect, it } from "bun:test";
 import { Source } from "./source";
-import { describe, it, expect } from "bun:test";
 
 describe("appendLineNumbers", () => {
   it("should return code with correct line numbers", () => {
     const code = Source.fromText(
       "dummy",
-      `function test() {\n  console.log("Hello, world!");\n}`
+      `function test() {\n  console.log("Hello, world!");\n}`,
     );
     const expected = `1: function test() {\n2:   console.log("Hello, world!");\n3: }`;
     expect(code.contentWithLineNumbers).toEqual(expected);

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -1,4 +1,4 @@
-import { LLM } from "./llm/mod";
+import type { LLM } from "./llm/mod";
 import { getLanguagePromptForJson } from "./utility/language";
 
 export type SummaryContext = {
@@ -75,15 +75,15 @@ export async function summarizeDiff(
       .replace(/^```json\n/, "")
       .replace(/\n```$/, "");
     const json = JSON.parse(replaced);
-    return json.changes.map((change: any) => ({
+    return json.changes.map((change: SummaryDiffItem) => ({
       category: change.category,
       description: change.description,
     }));
   } catch (e) {
     if (e instanceof Error) {
-      console.error(e.message + "\nRESULT:\n" + result);
+      console.error(`${e.message}\nRESULT:\n${result}`);
     } else {
-      console.error(e + "\nRESULT:\n" + result);
+      console.error(`${e}\nRESULT:\n${result}`);
     }
     throw new Error("Failed to parse summary");
   }

--- a/src/utility/deep-assign.test.ts
+++ b/src/utility/deep-assign.test.ts
@@ -1,4 +1,4 @@
-import { it, expect } from "bun:test";
+import { expect, it } from "bun:test";
 import { deepAssign } from "./deep-assign";
 
 it("deepAssign keep the property in the nested object", () => {

--- a/src/utility/deep-assign.ts
+++ b/src/utility/deep-assign.ts
@@ -4,8 +4,11 @@
  * @param sources 割り当てるオブジェクトの可変引数
  * @returns 割り当て後のオブジェクト
  */
-export function deepAssign(target: any, ...sources: any[]): any {
-  sources.forEach((source) => {
+export function deepAssign(
+  target: Record<string, unknown>,
+  ...sources: Partial<Record<string, unknown>>[]
+): Record<string, unknown> {
+  for (const source of sources) {
     // キーごとにループ
     for (const key in source) {
       if (Object.prototype.hasOwnProperty.call(source, key)) {
@@ -14,13 +17,16 @@ export function deepAssign(target: any, ...sources: any[]): any {
           if (!target[key] || typeof target[key] !== "object") {
             target[key] = {};
           }
-          deepAssign(target[key], source[key]);
+          target[key] = deepAssign(
+            target[key] as Record<string, unknown>,
+            source[key] as Record<string, unknown>,
+          );
         } else {
           // プリミティブ値の場合、直接割り当て
           target[key] = source[key];
         }
       }
     }
-  });
+  }
   return target;
 }

--- a/src/utility/language.ts
+++ b/src/utility/language.ts
@@ -1,4 +1,4 @@
-import { Config } from "@/config";
+import type { Config } from "@/config";
 
 export function getLanguagePromptForJson(
   language: string,
@@ -15,7 +15,8 @@ export function getLanguageFromConfig(config: Config) {
   const configLang = config.language.language.toLowerCase().trim();
   if (Bun.env.AICA_LANGUAGE) {
     return Bun.env.AICA_LANGUAGE;
-  } else if (configLang && configLang !== "auto") {
+  }
+  if (configLang && configLang !== "auto") {
     return configLang;
   }
   return getLanguageFromLang();

--- a/src/utility/parse-diff.ts
+++ b/src/utility/parse-diff.ts
@@ -11,11 +11,11 @@ const ignoredLines = ["--- /dev/null"];
 export function parseDiff(diffOutput: string): FileChange[] {
   const files: FileChange[] = [];
   const diffParts = diffOutput.split("diff --git ");
-  diffParts.slice(1).forEach((part) => {
+  for (const part of diffParts.slice(1)) {
     const lines = part.split("\n");
     const header = lines[0];
     const filenameMatch = header.match(/b\/(.*)/);
-    if (!filenameMatch) return;
+    if (!filenameMatch) continue;
 
     const filename = filenameMatch[1];
     const isNewFile = part.includes("new file mode");
@@ -29,7 +29,7 @@ export function parseDiff(diffOutput: string): FileChange[] {
       changeType,
       changes: changeLines,
     });
-  });
+  }
 
   return files;
 }


### PR DESCRIPTION
<!-- AICA GENERATED -->
## Summary

| Category | Description |
|---|---|
| feature | Added new configuration files: biome.json with biome settings and lefthook.yml for defining pre-commit and pre-push hooks. |
| enhance | Updated dependency versions and lock file entries in bun.lock, including adding biome and lefthook dependencies for multiple architectures. |
| enhance | Updated package.json scripts by adding new commands for linting and checking via biome (lint, check, check:unsafe). |
| refactor | Reordered and restructured import statements and added explicit 'type' annotations for various imports in many modules to improve code clarity and ensure proper static typing. |
| bugfix | Fixed logical bug in the command extraction logic: added validation to ensure command is not empty and throw an error if missing. |
| enhance | Improved string concatenation by converting many instances to template literals for better readability and maintainability. |
| refactor | Changed equality operator from '==' to '===' in condition checking GITHUB_ACTIONS to enforce strict equality. |
| refactor | Replaced forEach loops with for-of loops in parts of the code (e.g., processing addedFiles in agent.ts) to enhance code clarity. |
| enhance | Made several test files consistent in import ordering and module usage (e.g. using node:fs, node:path) to improve cross-environment compatibility. |
| refactor | Improved error handling by refining catch blocks (e.g., using 'error instanceof Error' checks and improved logging messages) across multiple modules. |
| enhance | Updated deepAssign utility function with stronger typing and clearer iterative logic. |