### PR TITLE
docs: update README and add agent introduction in system prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ export AICA_LANGUAGE=Japanese
 ```
 
 Priority:
+
 1. `AICA_LANGUAGE`
 2. `language.language` in aica.toml
 3. Automatic detection from `LANG`
@@ -126,6 +127,9 @@ aica agent "your prompt here"
 
 # execute AI agent with a instruction file
 aica agent -f instruction.txt
+
+# conversation mode. You can interact with AI agent by typing your prompt.
+aica agent
 ```
 
 This command executes a task using an AI agent. The agent automatically determines and executes the necessary actions based on the given prompt.
@@ -140,25 +144,6 @@ NOTE: This command has potential to break your file system. Please be careful.
 # reindex the code and document databases
 aica reindex
 ```
-
-### Chat
-
-```bash
-# chat with AI assistant using a prompt
-aica chat "prompt"
-
-# chat with AI assistant using a prompt file
-aica chat -f prompt.txt
-
-# conversation mode
-aica chat
-```
-
-This command provides functionality to chat with an AI assistant. You can interact with the AI assistant by either directly specifying a prompt or using a prompt file.
-
-Options:
-
-- `--file`, `-f`: Path to a prompt file
 
 ### Summary
 

--- a/src/agent/prompt/system-prompt.ts
+++ b/src/agent/prompt/system-prompt.ts
@@ -18,6 +18,9 @@ export async function getSystemPrompt(
   const rules = await rulesFinder.findAllRules(filePaths);
   const rulesPrompt = RulesFinder.buildPrompt(rules);
   return `
+Your name is Aica.
+You are an agent that help software developers to smoothly complete their tasks.
+
 ${getSystemInfoSection(cwd)}
 ${getObjectiveSection()}
 ${getSharedToolUseSection()}


### PR DESCRIPTION
<!-- AICA GENERATED -->
## Summary

| Category | Description |
|---|---|
| feature | Add conversation mode to the agent command, allowing users to interact with AI agent by typing prompts. |
| enhance | Add name 'Aica' and role description to the agent system prompt. |
| docs | Add documentation for the conversation mode in the agent command section. |
| docs | Improve README formatting by adding a blank line after 'Priority:' heading. |
| refactor | Remove the 'Chat' command section from README.md, likely consolidating chat functionality into the agent command. |