### PR TITLE
feat: add reasoningEffort & zod schema support, increase LLM token limits

### DIFF
--- a/aica.example.toml
+++ b/aica.example.toml
@@ -5,20 +5,20 @@ provider = 'anthropic'
 [llm.openai]
 model = 'o3-mini'
 temperature = 0.5
-maxCompletionTokens = 4096
+maxCompletionTokens = 20000
 reasoningEffort = 'medium'
 # logFile = '/path/to/openai.log'  # Optional: Path to log OpenAI API calls
 
 [llm.anthropic]
-model = 'claude-3-5-sonnet-20241022'
+model = 'claude-3-7-sonnet-20250219'
 temperature = 0.5
-maxTokens = 4096
+maxTokens = 8000
 # logFile = '/path/to/anthropic.log'  # Optional: Path to log Anthropic API calls
 
 [llm.google]
 model = 'gemini-2.0-flash'
 temperature = 0.5
-maxTokens = 4096
+maxTokens = 8000
 # logFile = '/path/to/google.log'  # Optional: Path to log Google API calls
 
 [rules]

--- a/aica.example.toml
+++ b/aica.example.toml
@@ -6,6 +6,7 @@ provider = 'anthropic'
 model = 'o3-mini'
 temperature = 0.5
 maxCompletionTokens = 4096
+reasoningEffort = 'medium'
 # logFile = '/path/to/openai.log'  # Optional: Path to log OpenAI API calls
 
 [llm.anthropic]

--- a/aica.example.toml
+++ b/aica.example.toml
@@ -3,7 +3,7 @@
 provider = 'anthropic'
 
 [llm.openai]
-model = 'o3-mini'
+model = 'o4-mini'
 temperature = 0.5
 maxCompletionTokens = 20000
 reasoningEffort = 'medium'

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { z } from "zod";
 import type { Config, LLMConfig } from "./config";
 import { createEmbeddingProducer } from "./embedding/mod";
 import {
@@ -13,7 +14,6 @@ import {
   getLanguageFromConfig,
   getLanguagePromptForJson,
 } from "./utility/language";
-import { z } from "zod";
 
 export type AnalyzeContext = {
   knowledgeTexts: string[];

--- a/src/commands/review-command.ts
+++ b/src/commands/review-command.ts
@@ -9,9 +9,9 @@ import { readConfig } from "@/config";
 import { sendToSlack } from "@/slack";
 import { Source, SourceFinder } from "@/source";
 
-import { z } from "zod";
 import { GitRepository } from "@/git";
 import { parseDiff } from "@/utility/parse-diff";
+import { z } from "zod";
 
 export const reviewCommandSchema = z.object({
   config: z.string().optional(),

--- a/src/config.ts
+++ b/src/config.ts
@@ -141,7 +141,7 @@ export const defaultConfig: Config = {
   llm: {
     provider: getDefaultLLMProvider(),
     openai: {
-      model: Bun.env.OPENAI_MODEL || "o3-mini",
+      model: Bun.env.OPENAI_MODEL || "o4-mini",
       apiKey: Bun.env.OPENAI_API_KEY || "",
       temperature: 0.5,
       maxCompletionTokens: 20000,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import { GitRepository } from "./git";
 import { deepAssign } from "./utility/deep-assign";
+import { OpenAIReasoningEffort } from "./llm/openai";
 
 export type LLMProvider = "openai" | "anthropic" | "stub" | "google";
 
@@ -10,6 +11,7 @@ export type LLMConfigOpenAI = {
   temperature: number;
   maxCompletionTokens: number;
   logFile: string | undefined;
+  reasoningEffort?: OpenAIReasoningEffort;
 };
 
 export type LLMConfigAnthropic = {
@@ -144,6 +146,7 @@ export const defaultConfig: Config = {
       temperature: 0.5,
       maxCompletionTokens: 4096,
       logFile: Bun.env.OPENAI_LOG_FILE || undefined,
+      reasoningEffort: "medium",
     },
     anthropic: {
       model: Bun.env.ANTHROPIC_MODEL || "claude-3-7-sonnet-20250219",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import { GitRepository } from "./git";
+import type { OpenAIReasoningEffort } from "./llm/openai";
 import { deepAssign } from "./utility/deep-assign";
-import { OpenAIReasoningEffort } from "./llm/openai";
 
 export type LLMProvider = "openai" | "anthropic" | "stub" | "google";
 
@@ -144,7 +144,7 @@ export const defaultConfig: Config = {
       model: Bun.env.OPENAI_MODEL || "o3-mini",
       apiKey: Bun.env.OPENAI_API_KEY || "",
       temperature: 0.5,
-      maxCompletionTokens: 4096,
+      maxCompletionTokens: 20000,
       logFile: Bun.env.OPENAI_LOG_FILE || undefined,
       reasoningEffort: "medium",
     },
@@ -152,14 +152,14 @@ export const defaultConfig: Config = {
       model: Bun.env.ANTHROPIC_MODEL || "claude-3-7-sonnet-20250219",
       apiKey: Bun.env.ANTHROPIC_API_KEY || "",
       temperature: 0.5,
-      maxTokens: 4096,
+      maxTokens: 8000,
       logFile: Bun.env.ANTHROPIC_LOG_FILE || undefined,
     },
     google: {
       model: Bun.env.GOOGLE_MODEL || "gemini-2.0-flash",
       apiKey: Bun.env.GOOGLE_API_KEY || Bun.env.GEMINI_API_KEY || "",
       temperature: 0.5,
-      maxTokens: 4096,
+      maxTokens: 8000,
       logFile: Bun.env.GOOGLE_LOG_FILE || undefined,
     },
     stub: {

--- a/src/github/review.test.ts
+++ b/src/github/review.test.ts
@@ -5,7 +5,7 @@ import { generateReview } from "./review";
 
 // Mock diff string
 const mockDiffString =
-  "diff --git a/file1.js b/file1.js\nindex 83db48f..bf3a6c4 100644\n--- a/file1.js\n+++ b/file1.js\n@@ -1,4 +1,4 @@\n-console.log('Hello World');\n+console.log('Hello, World!');";
+  "diff --git a/testdata/src/file1.ts b/testdata/src/file1.ts\nindex 83db48f..bf3a6c4 100644\n--- a/file1.js\n+++ b/file1.js\n@@ -1,4 +1,4 @@\n-console.log('Hello World');\n+console.log('Hello, World!');";
 
 // Test cases
 describe("generateReview", () => {

--- a/src/github/review.ts
+++ b/src/github/review.ts
@@ -15,7 +15,10 @@ export async function generateReview(
   const fileChanges = parseDiff(diffString);
   const sources: Source[] = [];
   for (const fileChange of fileChanges) {
-    const source = Source.fromPullRequestDiff(fileChange);
+    const source = Source.fromPullRequestDiff(
+      config.workingDirectory,
+      fileChange,
+    );
     sources.push(source);
   }
 

--- a/src/llm/llm.ts
+++ b/src/llm/llm.ts
@@ -1,3 +1,5 @@
+import type { z } from "zod";
+
 export interface LLMOptions {
   maxRetries?: number;
   retryDelay?: number;
@@ -8,6 +10,7 @@ export interface LLM {
     systemPrompt: string,
     prompts: Message[],
     jsonMode: boolean,
+    responseSchema?: z.ZodSchema,
     options?: LLMOptions,
   ): Promise<string>;
 }

--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -1,6 +1,6 @@
 import type { LLMConfigOpenAI } from "@/config";
-import { z } from "zod";
 import { zodResponseFormat } from "openai/helpers/zod";
+import type { z } from "zod";
 
 import {
   type LLM,

--- a/src/source.ts
+++ b/src/source.ts
@@ -18,10 +18,11 @@ export class Source {
   ) {}
 
   get targetSourceContent(): string {
-    if (this.type === SourceType.PullRequestDiff) {
-      return this.content;
-    }
     return `file: ${this.path}\n\n${this.contentWithLineNumbers}`;
+  }
+
+  get diff(): string | null {
+    return this.fileChange?.diff ?? null;
   }
 
   get contentWithLineNumbers(): string {
@@ -37,13 +38,13 @@ export class Source {
     return new Source(SourceType.File, filePath, content, null);
   }
 
-  static fromPullRequestDiff(change: FileChange): Source {
-    return new Source(
-      SourceType.PullRequestDiff,
-      change.filename,
-      change.changes.join("\n"),
-      change,
-    );
+  static fromPullRequestDiff(
+    repositoryDir: string,
+    change: FileChange,
+  ): Source {
+    const filePath = path.join(repositoryDir, change.filename);
+    const content = fs.readFileSync(filePath, "utf8");
+    return new Source(SourceType.PullRequestDiff, filePath, content, change);
   }
 
   private appendLineNumbers(code: string): string {

--- a/src/utility/parse-diff.ts
+++ b/src/utility/parse-diff.ts
@@ -3,10 +3,8 @@ export type ChangeType = "add" | "remove" | "modify";
 export interface FileChange {
   filename: string;
   changeType: ChangeType;
-  changes: string[];
+  diff: string;
 }
-
-const ignoredLines = ["--- /dev/null"];
 
 export function parseDiff(diffOutput: string): FileChange[] {
   const files: FileChange[] = [];
@@ -20,14 +18,11 @@ export function parseDiff(diffOutput: string): FileChange[] {
     const filename = filenameMatch[1];
     const isNewFile = part.includes("new file mode");
     const changeType: ChangeType = isNewFile ? "add" : "modify";
-    const changeLines = lines
-      .filter((line) => line.startsWith("+") || line.startsWith("-"))
-      .filter((line) => !ignoredLines.includes(line));
 
     files.push({
       filename,
       changeType,
-      changes: changeLines,
+      diff: part,
     });
   }
 

--- a/testdata/src/file1.ts
+++ b/testdata/src/file1.ts
@@ -1,0 +1,1 @@
+console.log('Hello, World!');


### PR DESCRIPTION
<!-- AICA GENERATED -->
## Summary

| Category | Description |
|---|---|
| enhance | Increase token limits for all LLM providers: OpenAI from 4096 to 20000, Anthropic and Google from 4096 to 8000 |
| feature | Add 'reasoningEffort' parameter for OpenAI models with default value 'medium' |
| enhance | Update Anthropic model from 'claude-3-5-sonnet-20241022' to 'claude-3-7-sonnet-20250219' |
| feature | Add Zod schema validation for API responses |
| enhance | Extend issue type definition to include 'file' field and add 'medium' and 'low' severity levels |
| enhance | Improve OpenAI response format handling with support for Zod schema validation |
| enhance | Add conditional logic for O-series models to handle response formats and reasoning effort differently |