### PR TITLE
chore: bump bun version and fix parseDiff filename regex

### DIFF
--- a/Dockerfile.github_actions
+++ b/Dockerfile.github_actions
@@ -1,4 +1,4 @@
-FROM oven/bun:1.2.3
+FROM oven/bun:1.2.12
 
 WORKDIR /app
 

--- a/src/utility/parse-diff.ts
+++ b/src/utility/parse-diff.ts
@@ -12,7 +12,7 @@ export function parseDiff(diffOutput: string): FileChange[] {
   for (const part of diffParts.slice(1)) {
     const lines = part.split("\n");
     const header = lines[0];
-    const filenameMatch = header.match(/b\/(.*)/);
+    const filenameMatch = header.match(/ b\/(.*)/);
     if (!filenameMatch) continue;
 
     const filename = filenameMatch[1];


### PR DESCRIPTION
<!-- AICA GENERATED -->
## Summary

| Category | Description |
|---|---|
| enhance | Update Bun version from 1.2.3 to 1.2.12 in Dockerfile.github_actions. |
| bugfix | Fix regex pattern in parse-diff.ts to correctly extract filenames by adding a space before 'b/' in the pattern. |